### PR TITLE
feat(preserve): preserve option in masking for null and empty values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Types of changes
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [1.9.3]
+
+- `Added` option preserve in masking configuration
+
 ## [1.9.2]
 
 - `Fixed` cache with mask `fluxUri`.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ masking:
       jsonpath: "example.example2"
     mask:
       type: "argument"
+    preserve: "null"
 
 caches:
   cacheName:
@@ -36,6 +37,7 @@ caches:
 `jsonpath` defines the path of the entry that has to be masked in the json file.
 `mask` defines the mask that will be used for the entry defined by `selector`.
 `cache` is optional, if the current entry is already in the cache as key the associated value is returned without executing the mask. Otherwise the mask is executed and a new entry is added in the cache with the orignal content as `key` and the masked result as `value`. The cache have to be declared in the `caches` section of the YAML file.
+`preserve` is optional, and is used to keep some values unmasked in the json file. Allowed `preserve` options are: `"null"` (null values), `"empty"` (empty string `""`), and `"blank"` (both `empty` and `null` values).
 
 Multiple masks can be applied on the same jsonpath location, like in this example :
 

--- a/pkg/model/cache_test.go
+++ b/pkg/model/cache_test.go
@@ -81,7 +81,7 @@ func TestFromCacheProcessShouldWaitForValueProvide(t *testing.T) {
 	var result []Dictionary
 
 	pipeline := NewPipelineFromSlice(mySlice).
-		Process(NewMaskEngineProcess(NewPathSelector("id"), NewMaskCacheEngine(cache, idMasking))).
+		Process(NewMaskEngineProcess(NewPathSelector("id"), NewMaskCacheEngine(cache, idMasking), "")).
 		Process(NewFromCacheProcess(NewPathSelector("supervisor"), cache)).
 		AddSink(NewSinkToSlice(&result))
 	err := pipeline.Run()
@@ -110,7 +110,7 @@ func TestFromCacheProcessShouldWaitForLoopProvid(t *testing.T) {
 	var result []Dictionary
 
 	pipeline := NewPipelineFromSlice(mySlice).
-		Process(NewMaskEngineProcess(NewPathSelector("id"), NewMaskCacheEngine(cache, idMasking))).
+		Process(NewMaskEngineProcess(NewPathSelector("id"), NewMaskCacheEngine(cache, idMasking), "")).
 		Process(NewFromCacheProcess(NewPathSelector("supervisor"), cache)).
 		AddSink(NewSinkToSlice(&result))
 	err := pipeline.Run()
@@ -142,7 +142,7 @@ func TestFromCacheProcessShouldUsedPreviouslyCachedValue(t *testing.T) {
 	var result []Dictionary
 
 	pipeline := NewPipelineFromSlice(mySlice).
-		Process(NewMaskEngineProcess(NewPathSelector("id"), NewMaskCacheEngine(cache, idMasking))).
+		Process(NewMaskEngineProcess(NewPathSelector("id"), NewMaskCacheEngine(cache, idMasking), "")).
 		Process(NewFromCacheProcess(NewPathSelector("supervisor"), cache)).
 		AddSink(NewSinkToSlice(&result))
 	err := pipeline.Run()
@@ -174,7 +174,7 @@ func TestFromCacheProcessShouldReorderList(t *testing.T) {
 	var result []Dictionary
 
 	pipeline := NewPipelineFromSlice(mySlice).
-		Process(NewMaskEngineProcess(NewPathSelector("id"), NewMaskCacheEngine(cache, idMasking))).
+		Process(NewMaskEngineProcess(NewPathSelector("id"), NewMaskCacheEngine(cache, idMasking), "")).
 		Process(NewFromCacheProcess(NewPathSelector("supervisor"), cache)).
 		AddSink(NewSinkToSlice(&result))
 	err := pipeline.Run()
@@ -206,7 +206,7 @@ func TestFromCacheProcessShouldWaitWithUnique(t *testing.T) {
 	var result []Dictionary
 
 	pipeline := NewPipelineFromSlice(mySlice).
-		Process(NewMaskEngineProcess(NewPathSelector("id"), NewUniqueMaskCacheEngine(cache, idMasking))).
+		Process(NewMaskEngineProcess(NewPathSelector("id"), NewUniqueMaskCacheEngine(cache, idMasking), "")).
 		Process(NewFromCacheProcess(NewPathSelector("supervisor"), cache)).
 		AddSink(NewSinkToSlice(&result))
 	err := pipeline.Run()

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -162,6 +162,7 @@ type Masking struct {
 	Mask     MaskType     `yaml:"mask,omitempty" jsonschema:"oneof_required=Mask"`
 	Masks    []MaskType   `yaml:"masks,omitempty" jsonschema:"oneof_required=Masks"`
 	Cache    string       `yaml:"cache,omitempty"`
+	Preserve string       `yaml:"preserve,omitempty"`
 }
 
 type CacheDefinition struct {

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -172,7 +172,7 @@ func TestPipelineWithMaskEngine(t *testing.T) {
 	var result []Dictionary
 
 	pipeline := NewPipelineFromSlice(mySlice).
-		Process(NewMaskEngineProcess(NewPathSelector("name"), nameMasking)).
+		Process(NewMaskEngineProcess(NewPathSelector("name"), nameMasking, "")).
 		AddSink(NewSinkToSlice(&result))
 	err := pipeline.Run()
 
@@ -210,7 +210,7 @@ func TestMaskEngineShouldNotCreateField(t *testing.T) {
 	var result []Dictionary
 
 	pipeline := NewPipelineFromSlice(mySlice).
-		Process(NewMaskEngineProcess(NewPathSelector("name"), nameMasking)).
+		Process(NewMaskEngineProcess(NewPathSelector("name"), nameMasking, "")).
 		AddSink(NewSinkToSlice(&result))
 	err := pipeline.Run()
 
@@ -257,7 +257,7 @@ func TestMaskEngineShouldMaskAllEntriesInArray(t *testing.T) {
 	var result []Dictionary
 
 	pipeline := NewPipelineFromSlice(mySlice).
-		Process(NewMaskEngineProcess(NewPathSelector("city"), nameMasking)).
+		Process(NewMaskEngineProcess(NewPathSelector("city"), nameMasking, "")).
 		AddSink(NewSinkToSlice(&result))
 	err := pipeline.Run()
 
@@ -274,7 +274,7 @@ func TestMaskEngineShouldMaskNestedEntry(t *testing.T) {
 	var result []Dictionary
 
 	pipeline := NewPipelineFromSlice(mySlice).
-		Process(NewMaskEngineProcess(NewPathSelector("address.city"), nameMasking)).
+		Process(NewMaskEngineProcess(NewPathSelector("address.city"), nameMasking, "")).
 		AddSink(NewSinkToSlice(&result))
 	err := pipeline.Run()
 
@@ -298,7 +298,7 @@ func TestMaskEngineShouldMaskNestedDictionariesArray(t *testing.T) {
 	var result []Dictionary
 
 	pipeline := NewPipelineFromSlice(mySlice).
-		Process(NewMaskEngineProcess(NewPathSelector("address.city"), nameMasking)).
+		Process(NewMaskEngineProcess(NewPathSelector("address.city"), nameMasking, "")).
 		AddSink(NewSinkToSlice(&result))
 	err := pipeline.Run()
 
@@ -328,7 +328,7 @@ func TestMaskEngineShouldMaskNestedArray(t *testing.T) {
 	var result []Dictionary
 
 	pipeline := NewPipelineFromSlice(mySlice).
-		Process(NewMaskEngineProcess(NewPathSelector("address.city"), nameMasking)).
+		Process(NewMaskEngineProcess(NewPathSelector("address.city"), nameMasking, "")).
 		AddSink(NewSinkToSlice(&result))
 	err := pipeline.Run()
 
@@ -391,7 +391,7 @@ func TestMaskEngineShouldMaskNestedArrays(t *testing.T) {
 	var result []Dictionary
 
 	pipeline := NewPipelineFromSlice(mySlice).
-		Process(NewMaskEngineProcess(NewPathSelector("persons.phonenumber"), nameMasking)).
+		Process(NewMaskEngineProcess(NewPathSelector("persons.phonenumber"), nameMasking, "")).
 		AddSink(NewSinkToSlice(&result))
 	err := pipeline.Run()
 
@@ -414,7 +414,7 @@ func TestMaskEngineShouldMaskNestedNestedArrays(t *testing.T) {
 	var result []Dictionary
 
 	pipeline := NewPipelineFromSlice(mySlice).
-		Process(NewMaskEngineProcess(NewPathSelector("elements.persons.phonenumber"), nameMasking)).
+		Process(NewMaskEngineProcess(NewPathSelector("elements.persons.phonenumber"), nameMasking, "")).
 		AddSink(NewSinkToSlice(&result))
 	err := pipeline.Run()
 
@@ -431,7 +431,7 @@ func TestInOutFormat1(t *testing.T) {
 	iput := `{"key": ["mask"]}`
 	idict := jsonlineToDictionaries(iput)
 	pipeline := NewPipelineFromSlice(idict).
-		Process(NewMaskEngineProcess(NewPathSelector("key"), masking)).
+		Process(NewMaskEngineProcess(NewPathSelector("key"), masking, "")).
 		AddSink(NewSinkToSlice(&odict))
 	err := pipeline.Run()
 
@@ -445,7 +445,7 @@ func TestInOutFormat2(t *testing.T) {
 	iput := `{"key1": [{"key2": "mask"}]}`
 	idict := jsonlineToDictionaries(iput)
 	pipeline := NewPipelineFromSlice(idict).
-		Process(NewMaskEngineProcess(NewPathSelector("key1.key2"), masking)).
+		Process(NewMaskEngineProcess(NewPathSelector("key1.key2"), masking, "")).
 		AddSink(NewSinkToSlice(&odict))
 	err := pipeline.Run()
 
@@ -470,8 +470,8 @@ func TestMaskEngineShouldMaskMultipleNestedNestedArrays(t *testing.T) {
 	var result []Dictionary
 
 	pipeline := NewPipelineFromSlice(mySlice).
-		Process(NewMaskEngineProcess(NewPathSelector("elements.persons.email"), emailMasking)).
-		Process(NewMaskEngineProcess(NewPathSelector("elements.persons.phonenumber"), nameMasking)).
+		Process(NewMaskEngineProcess(NewPathSelector("elements.persons.email"), emailMasking, "")).
+		Process(NewMaskEngineProcess(NewPathSelector("elements.persons.phonenumber"), nameMasking, "")).
 		AddSink(NewSinkToSlice(&result))
 	err := pipeline.Run()
 
@@ -489,7 +489,7 @@ func TestMaskEngineShouldReturnError(t *testing.T) {
 	var result []Dictionary
 
 	pipeline := NewPipelineFromSlice(mySlice).
-		Process(NewMaskEngineProcess(NewPathSelector("city"), errorMasking)).
+		Process(NewMaskEngineProcess(NewPathSelector("city"), errorMasking, "")).
 		AddSink(NewSinkToSlice(&result))
 	err := pipeline.Run()
 
@@ -558,7 +558,7 @@ func TestCacheShouldProvide(t *testing.T) {
 	var result []Dictionary
 
 	pipeline := NewPipelineFromSlice(mySlice).
-		Process(NewMaskEngineProcess(NewPathSelector("city"), NewMaskCacheEngine(cache, errorMasking))).
+		Process(NewMaskEngineProcess(NewPathSelector("city"), NewMaskCacheEngine(cache, errorMasking), "")).
 		AddSink(NewSinkToSlice(&result))
 	err := pipeline.Run()
 

--- a/pkg/model/pipeline.go
+++ b/pkg/model/pipeline.go
@@ -76,6 +76,7 @@ func BuildPipeline(pipeline Pipeline, conf Definition, caches map[string]Cache) 
 				Mask:     maskDefinition,
 				Masks:    nil,
 				Cache:    masking.Cache,
+				Preserve: masking.Preserve,
 			}
 
 			if virtualMask.Mask.FromCache != "" {
@@ -105,7 +106,7 @@ func BuildPipeline(pipeline Pipeline, conf Definition, caches map[string]Cache) 
 							mask = NewMaskCacheEngine(typedCache, mask)
 						}
 					}
-					pipeline = pipeline.Process(NewMaskEngineProcess(NewPathSelector(virtualMask.Selector.Jsonpath), mask))
+					pipeline = pipeline.Process(NewMaskEngineProcess(NewPathSelector(virtualMask.Selector.Jsonpath), mask, virtualMask.Preserve))
 					nbArg++
 				}
 			}

--- a/pkg/model/process_mask.go
+++ b/pkg/model/process_mask.go
@@ -23,13 +23,14 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-func NewMaskEngineProcess(selector Selector, mask MaskEngine) Processor {
-	return &MaskEngineProcess{selector, mask}
+func NewMaskEngineProcess(selector Selector, mask MaskEngine, preserve string) Processor {
+	return &MaskEngineProcess{selector, mask, preserve}
 }
 
 type MaskEngineProcess struct {
 	selector Selector
 	mask     MaskEngine
+	preserve string
 }
 
 func (mep *MaskEngineProcess) Open() error {
@@ -42,12 +43,21 @@ func (mep *MaskEngineProcess) ProcessDictionary(dictionary Dictionary, out Colle
 	defer func() { over.MDC().Remove("path") }()
 	result := CopyDictionary(dictionary)
 	applied := mep.selector.Apply(result, func(rootContext, parentContext Dictionary, key string, value Entry) (Action, Entry) {
-		masked, err := mep.mask.Mask(value, rootContext, parentContext)
-		if err != nil {
-			ret = err
+		switch {
+		case value == nil && (mep.preserve == "null" || mep.preserve == "blank"):
+			log.Trace().Msgf("Preserve %s value, skip masking", mep.preserve)
 			return NOTHING, nil
+		case value == "" && (mep.preserve == "empty" || mep.preserve == "blank"):
+			log.Trace().Msgf("Preserve %s value, skip masking", mep.preserve)
+			return NOTHING, nil
+		default:
+			masked, err := mep.mask.Mask(value, rootContext, parentContext)
+			if err != nil {
+				ret = err
+				return NOTHING, nil
+			}
+			return WRITE, masked
 		}
-		return WRITE, masked
 	})
 
 	if !applied {

--- a/schema/v1/pimo.schema.json
+++ b/schema/v1/pimo.schema.json
@@ -402,6 +402,9 @@
         },
         "cache": {
           "type": "string"
+        },
+        "preserve": {
+          "type": "string"
         }
       },
       "additionalProperties": false,

--- a/test/suites/masking_preserve.yml
+++ b/test/suites/masking_preserve.yml
@@ -1,0 +1,124 @@
+name: preserve option
+testcases:
+- name: w/o preserve
+  steps:
+  - script: rm -f masking.yml
+  - script: |-
+      cat > expected.txt <<EOF
+      {"name":"maskedName"}
+      {"name":"maskedName"}
+      {"name":"maskedName"}
+      EOF
+  - script: |-
+      cat > masking.yml <<EOF
+      version: "1"
+      masking:
+        - selector:
+            jsonpath: "name"
+          mask:
+            constant: "maskedName"
+      EOF
+  - script: |-
+      echo -e '{"name":"paul"}\n{"name":""}\n{"name":null}' | pimo > output.txt
+    assertions:
+    - result.code ShouldEqual 0
+    - result.systemerr ShouldBeEmpty
+  - script: |-
+      diff expected.txt output.txt
+    assertions:
+    - result.systemout ShouldBeEmpty
+  - script: rm -f expected.txt
+  - script: rm -f output.txt
+
+- name: preserve null values
+  steps:
+  - script: rm -f masking.yml
+  - script: |-
+      cat > expected.txt <<EOF
+      {"name":"maskedName"}
+      {"name":"maskedName"}
+      {"name":null}
+      EOF
+  - script: |-
+      cat > masking.yml <<EOF
+      version: "1"
+      masking:
+        - selector:
+            jsonpath: "name"
+          preserve: "null"
+          mask:
+            constant: "maskedName"
+      EOF
+  - script: |-
+      echo -e '{"name":"paul"}\n{"name":""}\n{"name":null}' | pimo > output.txt
+    assertions:
+    - result.code ShouldEqual 0
+    - result.systemerr ShouldBeEmpty
+  - script: |-
+      diff expected.txt output.txt
+    assertions:
+    - result.systemout ShouldBeEmpty
+  - script: rm -f expected.txt
+  - script: rm -f output.txt
+
+- name: preserve empty values
+  steps:
+  - script: rm -f masking.yml
+  - script: |-
+      cat > expected.txt <<EOF
+      {"name":"maskedName"}
+      {"name":""}
+      {"name":"maskedName"}
+      EOF
+  - script: |-
+      cat > masking.yml <<EOF
+      version: "1"
+      masking:
+        - selector:
+            jsonpath: "name"
+          preserve: "empty"
+          mask:
+            constant: "maskedName"
+      EOF
+  - script: |-
+      echo -e '{"name":"paul"}\n{"name":""}\n{"name":null}' | pimo > output.txt
+    assertions:
+    - result.code ShouldEqual 0
+    - result.systemerr ShouldBeEmpty
+  - script: |-
+      diff expected.txt output.txt
+    assertions:
+    - result.systemout ShouldBeEmpty
+  - script: rm -f expected.txt
+  - script: rm -f output.txt
+
+- name: preserve blank values
+  steps:
+  - script: rm -f masking.yml
+  - script: |-
+      cat > expected.txt <<EOF
+      {"name":"maskedName"}
+      {"name":""}
+      {"name":null}
+      EOF
+  - script: |-
+      cat > masking.yml <<EOF
+      version: "1"
+      masking:
+        - selector:
+            jsonpath: "name"
+          preserve: "blank"
+          mask:
+            constant: "maskedName"
+      EOF
+  - script: |-
+      echo -e '{"name":"paul"}\n{"name":""}\n{"name":null}' | pimo > output.txt
+    assertions:
+    - result.code ShouldEqual 0
+    - result.systemerr ShouldBeEmpty
+  - script: |-
+      diff expected.txt output.txt
+    assertions:
+    - result.systemout ShouldBeEmpty
+  - script: rm -f expected.txt
+  - script: rm -f output.txt


### PR DESCRIPTION
Based on issue https://github.com/CGI-FR/PIMO/issues/56

Possibility to use option `preserve` in `masking.yml` to keep some values unmasked.
**masking.yml**:
```yaml
version: "1"
masking:
  - selector:
       jsonpath: "name"
    preserve: "null"
    mask:
       constant: "maskedName"
```

```console
pimo << EOF 
{"name":"paul"}
{"name":null}
EOF
{"name":"maskedName"}
{"name":null}
```