### PR TITLE
fix(flow): corrects template values interpretation

### DIFF
--- a/pkg/flow/flow.go
+++ b/pkg/flow/flow.go
@@ -328,7 +328,7 @@ func flattenHash(mask model.MaskType) string {
 }
 
 func unescapeTemplateValues(templateValue, mask, jsonpath string, variables map[string]subgraph, maskSubgraph subgraph) subgraph {
-	regex := regexp.MustCompile(`\.([0-z,\_,-]+)`)
+	regex := regexp.MustCompile(`((?:({{)|\s)\.([^\_][0-z,-]+))`)
 	splittedTemplate := regex.FindAllSubmatch([]byte(templateValue), -1)
 	edges := make([]edge, 0, 10)
 	jsonpathMaskCount := len(variables[jsonpath].masks)
@@ -338,7 +338,8 @@ func unescapeTemplateValues(templateValue, mask, jsonpath string, variables map[
 			param: sanitizeParam(templateValue),
 		}
 
-		value := string(splittedTemplate[i][1])
+		value := string(splittedTemplate[i][3])
+
 		// to avoid confusion with intermediate steps (i.e. "name_1")
 		if strings.Contains(value, "#underscore;") {
 			value = value[0:strings.LastIndex(value, "#underscore;")]


### PR DESCRIPTION
- Ignores template values starting with an "_" character (i.e. `{{._2}}`)
- Fixes handling of email adresses (does not create 2 separate nodes when encoutering a dot in an email)