### PR TITLE
fix(orderedDict):  CleanDictionary panics with fromjson + pipe in pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Types of changes
 
 ## [1.12.0]
 
+- `Fixed` pimo doesn't panic anymore with fromjson and pipe mask
 - `Fixed` mask `replacement` with nested selectors
 - `Added` flag to mask input while a declared condition is met
 - `Added` flag to mask input until a declared condition is met

--- a/pkg/model/ordered_dict.go
+++ b/pkg/model/ordered_dict.go
@@ -106,17 +106,17 @@ func CleanDictionarySlice(dictSlice interface{}) []Dictionary {
 	switch typedInter := dictSlice.(type) {
 	case []interface{}:
 		for _, d := range typedInter {
-			result = append(result, CleanDictionary(CleanTypes(d)))
+			result = append(result, CleanDictionary(d))
 		}
 
 	case []Dictionary:
 		for _, d := range typedInter {
-			result = append(result, CleanDictionary(CleanTypes(d)))
+			result = append(result, CleanDictionary(d))
 		}
 
 	case []Entry:
 		for _, d := range typedInter {
-			result = append(result, CleanDictionary(CleanTypes(d)))
+			result = append(result, CleanDictionary(d))
 		}
 	}
 

--- a/pkg/model/ordered_dict.go
+++ b/pkg/model/ordered_dict.go
@@ -49,6 +49,12 @@ func CleanTypes(inter interface{}) interface{} {
 			dict.Set(k, CleanTypes(v))
 		}
 		return dict
+	case map[string]interface{}:
+		dict := NewDictionary()
+		for k, v := range typedInter {
+			dict.Set(k, CleanTypes(v))
+		}
+		return dict
 	case *Dictionary:
 		iter := typedInter.EntriesIter()
 		dict := NewDictionary()
@@ -97,21 +103,20 @@ func CleanDictionary(dict interface{}) Dictionary {
 
 func CleanDictionarySlice(dictSlice interface{}) []Dictionary {
 	result := []Dictionary{}
-
 	switch typedInter := dictSlice.(type) {
 	case []interface{}:
 		for _, d := range typedInter {
-			result = append(result, CleanDictionary(d))
+			result = append(result, CleanDictionary(CleanTypes(d)))
 		}
 
 	case []Dictionary:
 		for _, d := range typedInter {
-			result = append(result, CleanDictionary(d))
+			result = append(result, CleanDictionary(CleanTypes(d)))
 		}
 
 	case []Entry:
 		for _, d := range typedInter {
-			result = append(result, CleanDictionary(d))
+			result = append(result, CleanDictionary(CleanTypes(d)))
 		}
 	}
 


### PR DESCRIPTION
Close https://github.com/CGI-FR/PIMO/issues/53

### Source of the problem

- `fromjson` uses `json.Unmarshal`. The value returned in the exemple is of type `map[string]interface{}`
- `pipe` uses `model.CleanDictionary` before iterating over the dict. The cleaning operation just missed the type `map[string]interface{}` It now converts it to `model.Dictionary`
