### PR TITLE
fix(fromjson): doesn't panic anymore with 2 fromjson

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Types of changes
 
 ## [1.12.0]
 
-- `Fixed` pimo doesn't panic anymore with fromjson and pipe mask
+- `Fixed` pimo doesn't panic anymore with fromjson combined with pipe mask, or fromjson combined with another fromjson mask with nested selectors
 - `Fixed` mask `replacement` with nested selectors
 - `Added` flag to mask input while a declared condition is met
 - `Added` flag to mask input until a declared condition is met

--- a/pkg/fromjson/fromjson.go
+++ b/pkg/fromjson/fromjson.go
@@ -26,19 +26,19 @@ import (
 
 // MaskEngine is a value that will be the initialisation of the field when it's created
 type MaskEngine struct {
-	sourcefield string
+	sourcefield model.Selector
 }
 
 // NewMask return a MaskEngine from a value
 func NewMask(source string) MaskEngine {
-	return MaskEngine{source}
+	return MaskEngine{model.NewPathSelector(source)}
 }
 
 // MaskContext
 func (am MaskEngine) MaskContext(context model.Dictionary, key string, contexts ...model.Dictionary) (model.Dictionary, error) {
 	log.Info().Msg("Mask fromjson")
 
-	value := context.Get(am.sourcefield)
+	value, _ := am.sourcefield.Read(contexts[0])
 
 	switch t := value.(type) {
 	case string:
@@ -47,7 +47,7 @@ func (am MaskEngine) MaskContext(context model.Dictionary, key string, contexts 
 		if err != nil {
 			return context, err
 		}
-		context.Set(key, result)
+		context.Set(key, model.CleanTypes(result))
 	default:
 		log.Warn().Msg("Invalid type")
 	}

--- a/test/suites/mask_fromjson.yml
+++ b/test/suites/mask_fromjson.yml
@@ -68,3 +68,41 @@ testcases:
           - result.code ShouldEqual 0
           - result.systemout ShouldEqual {"sourcefield":"{\"property\":\"hello\"}","targetfield":{"property":"hello"}}
           - result.systemerr ShouldBeEmpty
+  - name: nested selectors
+    steps:
+      - script: rm -rf masking.yml
+      - script: |-
+          cat > masking.yml <<EOF
+          version: "1"
+          masking:
+            - selector:
+                jsonpath: "sourcefield.property"
+              mask:
+                fromjson: "sourcefield.property"
+          EOF
+          echo '{"sourcefield": {"property": "1.2"}}' | pimo
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldEqual {"sourcefield":{"property":1.2}}
+          - result.systemerr ShouldBeEmpty
+  - name: successive fromjson
+    steps:
+      - script: rm -rf masking.yml
+      - script: |-
+          cat > masking.yml <<EOF
+          version: "v1"
+          masking:
+            - selector:
+                jsonpath: "targetfield"
+              mask:
+                fromjson: "sourcefield"
+            - selector:
+                jsonpath: "targetfield.property"
+              mask:
+                fromjson: "targetfield.property"
+          EOF
+          echo '{"sourcefield": "{\"property\":\"1.2\"}", "targetfield": ""}' | pimo
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemout ShouldEqual {"sourcefield":"{\"property\":\"1.2\"}","targetfield":{"property":1.2}}
+          - result.systemerr ShouldBeEmpty

--- a/test/suites/masking-transcode.yml
+++ b/test/suites/masking-transcode.yml
@@ -1,0 +1,83 @@
+name: Weighted Choice features
+testcases:
+- name: weightedChoice mask
+  steps:
+  - script: rm -f masking.yml
+  - script: |-
+      cat > masking.yml <<EOF
+      version: "1"
+      masking:
+        - selector:
+            jsonpath: "name"
+          mask:
+            weightedChoice:
+              - choice: "Dupont"
+                weight: 9
+              - choice: "Dupond"
+                weight: 1
+      EOF
+  - script: |-
+      echo '{"name": "Toto"}' | pimo
+    assertions:
+    - result.code ShouldEqual 0
+    - result.systemoutjson.name ShouldBeIn Dupond Dupont
+    - result.systemerr ShouldBeEmpty
+- name: weighted choice should not always mask the same way
+  steps:
+  - script: rm -f masking.yml
+  - script: |-
+      cat > masking.yml <<EOF
+      version: "1"
+      masking:
+        - selector:
+            jsonpath: "name"
+          mask:
+            weightedChoice:
+              - choice: "Dupont"
+                weight: 9
+              - choice: "Dupond"
+                weight: 1
+      EOF
+  - script: |-
+      echo '{"name": "Toto"}' | pimo --repeat=50 > first.txt
+  - script: |-
+      echo '{"name": "Toto"}' | pimo --repeat=50 > second.txt
+  - script: |-
+      diff first.txt second.txt
+    assertions:
+    - result.systemout ShouldNotBeEmpty
+  - script: rm -f first.txt
+  - script: rm -f second.txt
+
+- name: muliple weighted choice with same source mask
+  steps:
+  - script: rm -f masking.yml
+  - script: |-
+      cat > masking.yml <<EOF
+      version: "1"
+      seed: 13
+      masking:
+        - selector:
+            jsonpath: "name"
+          mask:
+            weightedChoice:
+              - choice: "Dupont"
+                weight: 8
+              - choice: "Dupond"
+                weight: 2
+        - selector:
+            jsonpath: "name2"
+          mask:
+            weightedChoice:
+              - choice: "Dupont"
+                weight: 8
+              - choice: "Dupond"
+                weight: 2
+      EOF
+  - script: |-
+      echo '{"name": "Toto", "name2": ""}' | pimo
+    assertions:
+    - result.code ShouldEqual 0
+    - result.systemoutjson.name ShouldEqual Dupond
+    - result.systemoutjson.name2 ShouldEqual Dupont
+    - result.systemerr ShouldBeEmpty


### PR DESCRIPTION
Based on https://github.com/CGI-FR/PIMO/issues/55

2 things:
- `sourcefield` is now a model.Selector, not a string (nested json now works with fromjson) ( complete work done with https://github.com/CGI-FR/PIMO/pull/87)
- a call to `model.CleanTypes` is needed after masking with `fromjson` (complete work done with https://github.com/CGI-FR/PIMO/pull/88)