### PR TITLE
perf: flex json with fast decoder

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,12 @@ go 1.20
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.3
+	github.com/adrienaury/flexjson v0.0.0-20231012183712-b4abbdff5e4a
 	github.com/adrienaury/zeromdc v0.0.0-20221116212822-6a366c26ee61
 	github.com/capitalone/fpe v1.2.1
+	github.com/goccy/go-json v0.10.2
 	github.com/goccy/go-yaml v1.11.0
+	github.com/iancoleman/orderedmap v0.3.0
 	github.com/invopop/jsonschema v0.7.0
 	github.com/labstack/echo/v4 v4.11.1
 	github.com/mattn/anko v0.1.9
@@ -16,7 +19,6 @@ require (
 	github.com/spf13/cobra v1.7.0
 	github.com/stretchr/testify v1.8.4
 	github.com/zach-klippenstein/goregen v0.0.0-20160303162051-795b5e3961ea
-	gitlab.com/c0b/go-ordered-json v0.0.0-20201030195603-febf46534d5a
 	golang.org/x/text v0.12.0
 )
 
@@ -29,7 +31,6 @@ require (
 	github.com/google/gxui v0.0.0-20151028112939-f85e0a97b3a4 // indirect
 	github.com/google/uuid v1.1.2 // indirect
 	github.com/huandu/xstrings v1.3.3 // indirect
-	github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0 // indirect
 	github.com/imdario/mergo v0.3.11 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/labstack/gommon v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/Masterminds/semver/v3 v3.2.0 h1:3MEsd0SM6jqZojhjLWWeBY+Kcjy9i6MQAeY7Y
 github.com/Masterminds/semver/v3 v3.2.0/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/Masterminds/sprig/v3 v3.2.3 h1:eL2fZNezLomi0uOLqjQoN6BfsDD+fyLtgbJMAj9n6YA=
 github.com/Masterminds/sprig/v3 v3.2.3/go.mod h1:rXcFaZ2zZbLRJv/xSysmlgIM1u11eBaRMhvYXJNkGuM=
+github.com/adrienaury/flexjson v0.0.0-20231012183712-b4abbdff5e4a h1:NRMenNwG8M9GYZysPsEPgWVCp1E1RJ4Xtt/vwBkMzVc=
+github.com/adrienaury/flexjson v0.0.0-20231012183712-b4abbdff5e4a/go.mod h1:qZhyOMd1mo+TgiH/mKNlhpP237hNxeiRS3cdW2+I96w=
 github.com/adrienaury/zeromdc v0.0.0-20221116212822-6a366c26ee61 h1:GXmgCyG0oDr3BFL+NYcwKEP2H3L9DuBo66ZR++zNasA=
 github.com/adrienaury/zeromdc v0.0.0-20221116212822-6a366c26ee61/go.mod h1:5UlMlw0MRjEAms20gDadR5GrN2wEp9XEXTBiMp/XI4E=
 github.com/capitalone/fpe v1.2.1 h1:/r81KhhTkfmxjjr2HKr+WYTLrMjPnn0gtK/L8gKNfts=
@@ -19,6 +21,8 @@ github.com/frankban/quicktest v1.14.4 h1:g2rn0vABPOOXmZUj+vbmUp0lPoXEMuhTpIluN0X
 github.com/go-playground/locales v0.13.0 h1:HyWk6mgj5qFqCT5fjGBuRArbVDfE4hi8+e8ceBS/t7Q=
 github.com/go-playground/universal-translator v0.17.0 h1:icxd5fm+REJzpZx7ZfpaD876Lmtgy7VtROAbHHXk8no=
 github.com/go-playground/validator/v10 v10.4.1 h1:pH2c5ADXtd66mxoE0Zm9SUhxE20r7aM3F26W0hOn+GE=
+github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
+github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/goccy/go-yaml v1.11.0 h1:n7Z+zx8S9f9KgzG6KtQKf+kwqXZlLNR2F6018Dgau54=
 github.com/goccy/go-yaml v1.11.0/go.mod h1:H+mJrWtjPTJAHvRbV09MCK9xYwODM+wRTVFFTWckfng=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
@@ -34,8 +38,9 @@ github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGa
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/huandu/xstrings v1.3.3 h1:/Gcsuc1x8JVbJ9/rlye4xZnVAbEkGauT8lbebqcQws4=
 github.com/huandu/xstrings v1.3.3/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
-github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0 h1:i462o439ZjprVSFSZLZxcsoAe592sZB1rci2Z8j4wdk=
 github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0/go.mod h1:N0Wam8K1arqPXNWjMo21EXnBPOPp36vB07FNRdD2geA=
+github.com/iancoleman/orderedmap v0.3.0 h1:5cbR2grmZR/DiVt+VJopEhtVs9YGInGIxAoMJn+Ichc=
+github.com/iancoleman/orderedmap v0.3.0/go.mod h1:XuLcCUkdL5owUCQeF2Ue9uuw1EptkJDkXXS7VoV7XGE=
 github.com/imdario/mergo v0.3.11 h1:3tnifQM4i+fbajXKBHXWEH+KvNHqojZ778UH75j3bGA=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
@@ -103,8 +108,6 @@ github.com/valyala/fasttemplate v1.2.2/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zach-klippenstein/goregen v0.0.0-20160303162051-795b5e3961ea h1:CyhwejzVGvZ3Q2PSbQ4NRRYn+ZWv5eS1vlaEusT+bAI=
 github.com/zach-klippenstein/goregen v0.0.0-20160303162051-795b5e3961ea/go.mod h1:eNr558nEUjP8acGw8FFjTeWvSgU1stO7FAO6eknhHe4=
-gitlab.com/c0b/go-ordered-json v0.0.0-20201030195603-febf46534d5a h1:DxppxFKRqJ8WD6oJ3+ZXKDY0iMONQDl5UTg2aTyHh8k=
-gitlab.com/c0b/go-ordered-json v0.0.0-20201030195603-febf46534d5a/go.mod h1:NREvu3a57BaK0R1+ztrEzHWiZAihohNLQ6trPxlIqZI=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.3.0/go.mod h1:hebNnKkNXi2UzZN1eVRvBB7co0a+JxK6XbPiWVs/3J4=

--- a/pkg/add/add.go
+++ b/pkg/add/add.go
@@ -44,7 +44,7 @@ func NewMask(value model.Entry, tmpl tmpl.FuncMap, seed int64, seedField string)
 // MaskContext add the field
 func (am MaskEngine) MaskContext(context model.Dictionary, key string, contexts ...model.Dictionary) (model.Dictionary, error) {
 	log.Info().Msg("Mask add")
-	_, present := context.GetValue(key)
+	_, present := context.OrderedMap.Get(key)
 	if !present {
 		if am.template != nil {
 			var output bytes.Buffer

--- a/pkg/addtransient/add-transient.go
+++ b/pkg/addtransient/add-transient.go
@@ -44,7 +44,7 @@ func NewMask(value model.Entry, tmpl tmpl.FuncMap, seed int64, seedField string)
 // MaskContext add the field
 func (am MaskEngine) MaskContext(context model.Dictionary, key string, contexts ...model.Dictionary) (model.Dictionary, error) {
 	log.Info().Msg("Mask add-transient")
-	_, present := context.GetValue(key)
+	_, present := context.OrderedMap.Get(key)
 	if !present {
 		if am.template != nil {
 			var output bytes.Buffer

--- a/pkg/jsonline/jsonline.go
+++ b/pkg/jsonline/jsonline.go
@@ -19,9 +19,12 @@ package jsonline
 
 import (
 	"bufio"
-	"encoding/json"
+	"bytes"
 	"io"
 
+	json "github.com/goccy/go-json"
+
+	"github.com/adrienaury/flexjson"
 	over "github.com/adrienaury/zeromdc"
 	"github.com/cgi-fr/pimo/pkg/model"
 )
@@ -125,9 +128,19 @@ func (s Sink) ProcessDictionary(dictionary model.Entry) error {
 
 // JSONToDictionary return a model.Dictionary from a jsonline
 func JSONToDictionary(jsonline []byte) (model.Dictionary, error) {
-	dict := model.NewDictionary()
+	decoder := json.NewDecoder(bytes.NewReader(jsonline))
+	flex := flexjson.NewFlexDecoder(
+		decoder,
+		func() (model.Dictionary, error) { return model.NewDictionary(), nil },
+		func(obj model.Dictionary, key string, value any) (model.Dictionary, error) {
+			obj.Set(key, value)
+			return obj, nil
+		},
+		flexjson.StandardArrayMaker(),
+		flexjson.StandardArrayAdder(),
+	)
 
-	err := json.Unmarshal(jsonline, &dict)
+	dict, err := flex.DecodeObject()
 	if err != nil {
 		return model.NewDictionary(), err
 	}
@@ -137,9 +150,19 @@ func JSONToDictionary(jsonline []byte) (model.Dictionary, error) {
 
 // JSONToPackedDictionary return a packed model.Dictionary from a jsonline
 func JSONToPackedDictionary(jsonline []byte) (model.Dictionary, error) {
-	dict := model.NewDictionary()
+	decoder := json.NewDecoder(bytes.NewReader(jsonline))
+	flex := flexjson.NewFlexDecoder(
+		decoder,
+		func() (model.Dictionary, error) { return model.NewDictionary(), nil },
+		func(obj model.Dictionary, key string, value any) (model.Dictionary, error) {
+			obj.Set(key, value)
+			return obj, nil
+		},
+		flexjson.StandardArrayMaker(),
+		flexjson.StandardArrayAdder(),
+	)
 
-	err := json.Unmarshal(jsonline, &dict)
+	dict, err := flex.DecodeObject()
 	if err != nil {
 		return model.NewDictionary(), err
 	}

--- a/pkg/jsonline/jsonline_test.go
+++ b/pkg/jsonline/jsonline_test.go
@@ -42,12 +42,12 @@ func TestSourceReturnDictionary(t *testing.T) {
 }
 
 func TestSourceReturnError(t *testing.T) {
-	jsonline := []byte(`{"personne" [{"name": "Benjamin", "age" : 35}, {"name": "Nicolas", "age" : 38}]}`)
+	jsonline := []byte(`{"personne: [{"name": "Benjamin", "age" : 35}, {"name": "Nicolas", "age" : 38}]}`)
 	pipeline := model.NewPipeline(NewSource(bytes.NewReader(jsonline)))
 	var result []model.Entry
 	err := pipeline.AddSink(model.NewSinkToSlice(&result)).Run()
 	assert.NotNil(t, err)
-	assert.EqualError(t, err, "invalid character '[' after object key")
+	assert.EqualError(t, err, "json: invalid character a as null")
 }
 
 func TestSinkWriteDictionary(t *testing.T) {

--- a/pkg/model/cache.go
+++ b/pkg/model/cache.go
@@ -152,13 +152,13 @@ func (mcce MaskContextCacheEngine) MaskContext(context Dictionary,
 	key string,
 	contexts ...Dictionary,
 ) (Dictionary, error) {
-	e, _ := context.GetValue(key)
+	e, _ := context.OrderedMap.Get(key)
 	if _, isInCache := mcce.Cache.Get(e); isInCache {
 		return context, nil
 	}
 	dict, err := mcce.OriginalEngine.MaskContext(context, key, contexts...)
 	if err == nil {
-		value, _ := dict.GetValue(key)
+		value, _ := dict.OrderedMap.Get(key)
 		mcce.Cache.Put(e, value)
 	}
 
@@ -210,7 +210,7 @@ func (umcce UniqueMaskContextCacheEngine) MaskContext(context Dictionary,
 	key string,
 	contexts ...Dictionary,
 ) (Dictionary, error) {
-	e, _ := context.GetValue(key)
+	e, _ := context.OrderedMap.Get(key)
 	if _, isInCache := umcce.cache.Get(e); isInCache {
 		return context, nil
 	}

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -354,7 +354,7 @@ func (p RepeaterUntilProcess) ProcessDictionary(dictionary Dictionary, out Colle
 		log.Warn().AnErr("error", err).Msg("Line skipped")
 		statistics.IncIgnoredLinesCount()
 		if p.errlogger != nil {
-			if msg, ok := dictionary.GetValue("original"); !ok {
+			if msg, ok := dictionary.OrderedMap.Get("original"); !ok {
 				return nil
 			} else if msgstr, ok := msg.(string); !ok {
 				return nil

--- a/pkg/model/model_test.go
+++ b/pkg/model/model_test.go
@@ -225,7 +225,7 @@ type TestAddMaskEngine struct {
 
 // MaskContext add the field
 func (am TestAddMaskEngine) MaskContext(context Dictionary, key string, contexts ...Dictionary) (Dictionary, error) {
-	_, present := context.GetValue(key)
+	_, present := context.OrderedMap.Get(key)
 	if !present {
 		context.Set(key, am.value)
 	}

--- a/pkg/model/ordered_dict.go
+++ b/pkg/model/ordered_dict.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	ordered "github.com/iancoleman/orderedmap"
 	"github.com/rs/zerolog/log"
-	"gitlab.com/c0b/go-ordered-json"
 )
 
 type Dictionary struct {
@@ -17,7 +17,7 @@ func NewPackedDictionary() Dictionary {
 }
 
 func NewDictionary() Dictionary {
-	return Dictionary{ordered.NewOrderedMap()}
+	return Dictionary{ordered.New()}
 }
 
 func Copy(other Entry) Entry {
@@ -37,19 +37,15 @@ func CopyDictionary(other Dictionary) Dictionary {
 		return NewDictionary()
 	}
 
-	om := ordered.NewOrderedMap()
-	iter := other.EntriesIter()
+	om := ordered.New()
 
-	for {
-		pair, ok := iter()
-		if !ok {
-			break
-		}
-		switch typedVal := pair.Value.(type) {
+	for _, key := range other.Keys() {
+		value := other.Get(key)
+		switch typedVal := value.(type) {
 		case Dictionary:
-			om.Set(pair.Key, CopyDictionary(typedVal))
+			om.Set(key, CopyDictionary(typedVal))
 		default:
-			om.Set(pair.Key, pair.Value)
+			om.Set(key, value)
 		}
 	}
 	return Dictionary{om}
@@ -72,31 +68,29 @@ func CleanTypes(inter interface{}) interface{} {
 		}
 		return dict
 	case *Dictionary:
-		iter := typedInter.EntriesIter()
 		dict := NewDictionary()
-		for pair, ok := iter(); ok; pair, ok = iter() {
-			dict.Set(pair.Key, CleanTypes(pair.Value))
+		for _, key := range typedInter.Keys() {
+			dict.Set(key, CleanTypes(typedInter.Get(key)))
 		}
 		return dict
 	case Dictionary:
-		iter := typedInter.EntriesIter()
 		dict := NewDictionary()
-		for pair, ok := iter(); ok; pair, ok = iter() {
-			dict.Set(pair.Key, CleanTypes(pair.Value))
+		for _, key := range typedInter.Keys() {
+			dict.Set(key, CleanTypes(typedInter.Get(key)))
 		}
 		return dict
 	case *ordered.OrderedMap:
-		iter := typedInter.EntriesIter()
 		dict := NewDictionary()
-		for pair, ok := iter(); ok; pair, ok = iter() {
-			dict.Set(pair.Key, CleanTypes(pair.Value))
+		for _, key := range typedInter.Keys() {
+			value, _ := typedInter.Get(key)
+			dict.Set(key, CleanTypes(value))
 		}
 		return dict
 	case ordered.OrderedMap:
-		iter := typedInter.EntriesIter()
 		dict := NewDictionary()
-		for pair, ok := iter(); ok; pair, ok = iter() {
-			dict.Set(pair.Key, CleanTypes(pair.Value))
+		for _, key := range typedInter.Keys() {
+			value, _ := typedInter.Get(key)
+			dict.Set(key, CleanTypes(value))
 		}
 		return dict
 	case []interface{}:
@@ -165,31 +159,29 @@ func Untyped(inter interface{}) interface{} {
 		}
 		return cleanmap
 	case *Dictionary:
-		iter := typedInter.EntriesIter()
 		cleanmap := map[string]interface{}{}
-		for pair, ok := iter(); ok; pair, ok = iter() {
-			cleanmap[pair.Key] = Untyped(pair.Value)
+		for _, key := range typedInter.Keys() {
+			cleanmap[key] = Untyped(typedInter.Get(key))
 		}
 		return cleanmap
 	case Dictionary:
-		iter := typedInter.EntriesIter()
 		cleanmap := map[string]interface{}{}
-		for pair, ok := iter(); ok; pair, ok = iter() {
-			cleanmap[pair.Key] = Untyped(pair.Value)
+		for _, key := range typedInter.Keys() {
+			cleanmap[key] = Untyped(typedInter.Get(key))
 		}
 		return cleanmap
 	case *ordered.OrderedMap:
-		iter := typedInter.EntriesIter()
 		cleanmap := map[string]interface{}{}
-		for pair, ok := iter(); ok; pair, ok = iter() {
-			cleanmap[pair.Key] = Untyped(pair.Value)
+		for _, key := range typedInter.Keys() {
+			value, _ := typedInter.Get(key)
+			cleanmap[key] = Untyped(value)
 		}
 		return cleanmap
 	case ordered.OrderedMap:
-		iter := typedInter.EntriesIter()
 		cleanmap := map[string]interface{}{}
-		for pair, ok := iter(); ok; pair, ok = iter() {
-			cleanmap[pair.Key] = Untyped(pair.Value)
+		for _, key := range typedInter.Keys() {
+			value, _ := typedInter.Get(key)
+			cleanmap[key] = Untyped(value)
 		}
 		return cleanmap
 	case []interface{}:
@@ -234,31 +226,29 @@ func UnorderedTypes(inter interface{}) interface{} {
 		}
 		return cleanmap
 	case *Dictionary:
-		iter := typedInter.EntriesIter()
 		cleanmap := map[string]Entry{}
-		for pair, ok := iter(); ok; pair, ok = iter() {
-			cleanmap[pair.Key] = UnorderedTypes(pair.Value)
+		for _, key := range typedInter.Keys() {
+			cleanmap[key] = UnorderedTypes(typedInter.Get(key))
 		}
 		return cleanmap
 	case Dictionary:
-		iter := typedInter.EntriesIter()
 		cleanmap := map[string]Entry{}
-		for pair, ok := iter(); ok; pair, ok = iter() {
-			cleanmap[pair.Key] = UnorderedTypes(pair.Value)
+		for _, key := range typedInter.Keys() {
+			cleanmap[key] = UnorderedTypes(typedInter.Get(key))
 		}
 		return cleanmap
 	case *ordered.OrderedMap:
-		iter := typedInter.EntriesIter()
 		cleanmap := map[string]Entry{}
-		for pair, ok := iter(); ok; pair, ok = iter() {
-			cleanmap[pair.Key] = UnorderedTypes(pair.Value)
+		for _, key := range typedInter.Keys() {
+			value, _ := typedInter.Get(key)
+			cleanmap[key] = UnorderedTypes(value)
 		}
 		return cleanmap
 	case ordered.OrderedMap:
-		iter := typedInter.EntriesIter()
 		cleanmap := map[string]Entry{}
-		for pair, ok := iter(); ok; pair, ok = iter() {
-			cleanmap[pair.Key] = UnorderedTypes(pair.Value)
+		for _, key := range typedInter.Keys() {
+			value, _ := typedInter.Get(key)
+			cleanmap[key] = UnorderedTypes(value)
 		}
 		return cleanmap
 	case []interface{}:
@@ -294,7 +284,7 @@ func UnorderedTypes(inter interface{}) interface{} {
 }
 
 func (d Dictionary) IsPacked() bool {
-	_, packed := d.GetValue(".")
+	_, packed := d.OrderedMap.Get(".")
 	return packed
 }
 
@@ -344,4 +334,9 @@ func (d Dictionary) With(key string, value interface{}) Dictionary {
 	result := CleanDictionary(d)
 	result.Set(key, CleanTypes(value))
 	return result
+}
+
+func (d Dictionary) Get(key string) Entry {
+	entry, _ := d.OrderedMap.Get(key)
+	return entry
 }

--- a/pkg/model/ordered_dict.go
+++ b/pkg/model/ordered_dict.go
@@ -1,9 +1,11 @@
 package model
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 
+	goccy "github.com/goccy/go-json"
 	ordered "github.com/iancoleman/orderedmap"
 	"github.com/rs/zerolog/log"
 )
@@ -339,4 +341,28 @@ func (d Dictionary) With(key string, value interface{}) Dictionary {
 func (d Dictionary) Get(key string) Entry {
 	entry, _ := d.OrderedMap.Get(key)
 	return entry
+}
+
+func (d Dictionary) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	buf.WriteByte('{')
+	encoder := goccy.NewEncoder(&buf)
+	for i, k := range d.Keys() {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		// add key
+		if err := encoder.Encode(k); err != nil {
+			return nil, err
+		}
+		buf.Truncate(buf.Len() - 1) // remove last new line
+		buf.WriteByte(':')
+		// add value
+		if err := encoder.Encode(d.Get(k)); err != nil {
+			return nil, err
+		}
+		buf.Truncate(buf.Len() - 1) // remove last new line
+	}
+	buf.WriteByte('}')
+	return buf.Bytes(), nil
 }

--- a/pkg/model/process_mask.go
+++ b/pkg/model/process_mask.go
@@ -79,7 +79,7 @@ func (mep *MaskEngineProcess) ProcessDictionary(dictionary Dictionary, out Colle
 		log.Warn().AnErr("error", ret).Msg("Line skipped")
 		statistics.IncIgnoredLinesCount()
 		if mep.errlogger != nil {
-			if msg, ok := dictionary.GetValue("original"); !ok {
+			if msg, ok := dictionary.OrderedMap.Get("original"); !ok {
 				return nil
 			} else if msgstr, ok := msg.(string); !ok {
 				return nil

--- a/pkg/model/process_maskcontext.go
+++ b/pkg/model/process_maskcontext.go
@@ -52,7 +52,7 @@ func (mcep *MaskContextEngineProcess) ProcessDictionary(dictionary Dictionary, o
 			ret = err
 			return NOTHING, nil
 		}
-		value, ok := masked.GetValue(key)
+		value, ok := masked.OrderedMap.Get(key)
 		if !ok {
 			return NOTHING, nil
 		}
@@ -72,7 +72,7 @@ func (mcep *MaskContextEngineProcess) ProcessDictionary(dictionary Dictionary, o
 		log.Warn().AnErr("error", ret).Msg("Line skipped")
 		statistics.IncIgnoredLinesCount()
 		if mcep.errlogger != nil {
-			if msg, ok := dictionary.GetValue("original"); !ok {
+			if msg, ok := dictionary.OrderedMap.Get("original"); !ok {
 				return nil
 			} else if msgstr, ok := msg.(string); !ok {
 				return nil

--- a/pkg/model/selector.go
+++ b/pkg/model/selector.go
@@ -92,7 +92,7 @@ func (s selector) Apply(root Dictionary, appliers ...Applier) bool {
 }
 
 func (s selector) applySub(root Dictionary, current Dictionary, appliers ...Applier) bool {
-	entry, ok := current.GetValue(s.path)
+	entry, ok := current.OrderedMap.Get(s.path)
 	if !ok {
 		return false
 	}
@@ -178,7 +178,7 @@ func (s selector) ApplyContext(root Dictionary, appliers ...Applier) bool {
 }
 
 func (s selector) applySubContext(root Dictionary, current Dictionary, appliers ...Applier) bool {
-	entry, ok := current.GetValue(s.path)
+	entry, ok := current.OrderedMap.Get(s.path)
 	if !ok {
 		if s.sub == nil {
 			// apply with nil value

--- a/pkg/model/selector_test.go
+++ b/pkg/model/selector_test.go
@@ -135,7 +135,7 @@ func TestDeleteSingle(t *testing.T) {
 		return model.DELETE, nil
 	})
 	assert.True(t, found)
-	_, exist := dictionary.GetValue("id")
+	_, exist := dictionary.OrderedMap.Get("id")
 	assert.False(t, exist)
 }
 

--- a/pkg/pipe/pipe.go
+++ b/pkg/pipe/pipe.go
@@ -62,7 +62,7 @@ func (me MaskEngine) MaskContext(e model.Dictionary, key string, context ...mode
 
 	copy := model.CopyDictionary(e)
 
-	value, ok := e.GetValue(key)
+	value, ok := e.OrderedMap.Get(key)
 	if !ok || value == nil {
 		return copy, nil
 	}

--- a/pkg/templateeach/template-each.go
+++ b/pkg/templateeach/template-each.go
@@ -72,7 +72,7 @@ func (tmpl MaskEngine) MaskContext(context model.Dictionary, key string, context
 		tmplctx = contexts[0].Unordered()
 	}
 
-	value, ok := copy.GetValue(key)
+	value, ok := copy.OrderedMap.Get(key)
 	if ok {
 		switch typedVal := model.CleanTypes(value).(type) {
 		case []model.Entry:

--- a/test/suites/mask_pipe.yml
+++ b/test/suites/mask_pipe.yml
@@ -15,4 +15,4 @@ testcases:
         assertions:
           - result.code  ShouldEqual 4
           - result.systemout ShouldEqual {}
-          - result.systemerr ShouldContainSubstring unexpected end of JSON input
+          - result.systemerr ShouldContainSubstring EOF


### PR DESCRIPTION
Achieved a processing time reduction of between 20% and 35% (depending on the size of the JSON input).

**BenchmarkPimoRun**

Benchmark | ns/op | B/op | allocs/op
-- | --:| --:| --:
Before | 35003 ns/op | 17382 B/op | 180 allocs/op
After | 27521 ns/op | 16176 B/op | 135 allocs/op

**BenchmarkPimoRunLarge**

Benchmark | ns/op | B/op | allocs/op
-- | --:| --:| --:
Before | 2264027 ns/op | 683047 B/op | 5905 allocs/op
After | 1494579 ns/op | 531007 B/op | 1754 allocs/op
