### PR TITLE
perf: clean types and json performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,10 @@ Types of changes
 
 ## [1.27.0]
 
-- `Added` parameter `maxstrlen` to `sha3` and `haqhInCSV` masks
-- `Fixed` type casting issues when using `add`, `add-transient`, `choice` or `hash` to create complex structures
+- `Added` parameter `maxstrlen` to `sha3` and `hashInCSV` masks
+- `Fixed` type casting issues when using `add`, `add-transient`, `choice`, `weightedChoice` or `hash` to create complex structures
+- `Fixed` performance issue with `pipe` mask
+- `Fixed` performance issue with selectors
 
 ## [1.26.2]
 

--- a/pkg/jsonline/jsonline.go
+++ b/pkg/jsonline/jsonline.go
@@ -19,8 +19,9 @@ package jsonline
 
 import (
 	"bufio"
-	"encoding/json"
 	"io"
+
+	json "github.com/goccy/go-json"
 
 	over "github.com/adrienaury/zeromdc"
 	"github.com/cgi-fr/pimo/pkg/model"
@@ -126,26 +127,11 @@ func (s Sink) ProcessDictionary(dictionary model.Entry) error {
 // JSONToDictionary return a model.Dictionary from a jsonline
 func JSONToDictionary(jsonline []byte) (model.Dictionary, error) {
 	dict := model.NewDictionary()
-
-	err := json.Unmarshal(jsonline, &dict)
-	if err != nil {
-		return model.NewDictionary(), err
-	}
-
-	return model.CleanDictionary(dict), nil
+	return dict, dict.UnmarshalJSON(jsonline)
 }
 
 // JSONToPackedDictionary return a packed model.Dictionary from a jsonline
 func JSONToPackedDictionary(jsonline []byte) (model.Dictionary, error) {
-	dict := model.NewDictionary()
-
-	err := json.Unmarshal(jsonline, &dict)
-	if err != nil {
-		return model.NewDictionary(), err
-	}
-
-	// packer
-	root := dict.Pack().With("original", string(jsonline))
-
-	return model.CleanDictionary(root), nil
+	dict, err := JSONToDictionary(jsonline)
+	return dict.Pack().With("original", string(jsonline)), err
 }

--- a/pkg/jsonline/jsonline.go
+++ b/pkg/jsonline/jsonline.go
@@ -126,9 +126,7 @@ func (s Sink) ProcessDictionary(dictionary model.Entry) error {
 // JSONToDictionary return a model.Dictionary from a jsonline
 func JSONToDictionary(jsonline []byte) (model.Dictionary, error) {
 	dict := model.NewDictionary()
-
 	err := dict.UnmarshalJSON(jsonline)
-
 	return model.CleanDictionary(dict), err
 }
 

--- a/pkg/jsonline/jsonline.go
+++ b/pkg/jsonline/jsonline.go
@@ -21,10 +21,9 @@ import (
 	"bufio"
 	"io"
 
-	json "github.com/goccy/go-json"
-
 	over "github.com/adrienaury/zeromdc"
 	"github.com/cgi-fr/pimo/pkg/model"
+	"github.com/goccy/go-json"
 )
 
 // NewSource creates a new Source.
@@ -127,7 +126,10 @@ func (s Sink) ProcessDictionary(dictionary model.Entry) error {
 // JSONToDictionary return a model.Dictionary from a jsonline
 func JSONToDictionary(jsonline []byte) (model.Dictionary, error) {
 	dict := model.NewDictionary()
-	return dict, dict.UnmarshalJSON(jsonline)
+
+	err := dict.UnmarshalJSON(jsonline)
+
+	return model.CleanDictionary(dict), err
 }
 
 // JSONToPackedDictionary return a packed model.Dictionary from a jsonline

--- a/pkg/model/ordered_dict.go
+++ b/pkg/model/ordered_dict.go
@@ -109,18 +109,14 @@ func CleanTypes(inter interface{}) interface{} {
 		}
 		return tab
 	case json.Number:
-
 		resFloat64, err := typedInter.Float64()
 		if err == nil {
 			return resFloat64
 		}
-
 		return typedInter.String()
-
 	case uint64:
 		res := float64(typedInter)
 		return res
-
 	case int64:
 		res := float64(typedInter)
 		return res
@@ -259,29 +255,23 @@ func UnorderedTypes(inter interface{}) interface{} {
 		return cleanmap
 	case []interface{}:
 		tab := []Entry{}
-
 		for _, item := range typedInter {
 			tab = append(tab, UnorderedTypes(item))
 		}
-
 		return tab
 
 	case []Dictionary:
 		tab := []Entry{}
-
 		for _, item := range typedInter {
 			tab = append(tab, UnorderedTypes(item))
 		}
-
 		return tab
 
 	case []Entry:
 		tab := []Entry{}
-
 		for _, item := range typedInter {
 			tab = append(tab, UnorderedTypes(item))
 		}
-
 		return tab
 
 	default:

--- a/pkg/model/ordered_dict.go
+++ b/pkg/model/ordered_dict.go
@@ -188,29 +188,23 @@ func Untyped(inter interface{}) interface{} {
 		return cleanmap
 	case []interface{}:
 		tab := []Entry{}
-
 		for _, item := range typedInter {
 			tab = append(tab, Untyped(item))
 		}
-
 		return tab
 
 	case []Dictionary:
 		tab := []interface{}{}
-
 		for _, item := range typedInter {
 			tab = append(tab, Untyped(item))
 		}
-
 		return tab
 
 	case []Entry:
 		tab := []interface{}{}
-
 		for _, item := range typedInter {
 			tab = append(tab, Untyped(item))
 		}
-
 		return tab
 
 	default:

--- a/pkg/pipe/pipe.go
+++ b/pkg/pipe/pipe.go
@@ -55,26 +55,22 @@ func NewMask(seed int64, injectParent string, injectRoot string, caches map[stri
 	return MaskEngine{"", pipeline, injectParent, injectRoot}, err
 }
 
-func (me MaskEngine) MaskContext(e model.Dictionary, key string, context ...model.Dictionary) (model.Dictionary, error) {
+func (me MaskEngine) MaskContext(entry model.Dictionary, key string, context ...model.Dictionary) (model.Dictionary, error) {
 	log.Info().Msg("Mask pipe")
 	var result []model.Entry
 	input := []model.Dictionary{}
 
-	// copy := model.CopyDictionary(e)
-	copy := e
-
-	value, ok := e.GetValue(key)
+	value, ok := entry.GetValue(key)
 	if !ok || value == nil {
-		return copy, nil
+		return entry, nil
 	}
 
-	for _, elemInput := range model.CleanDictionarySlice(e.Get(key)) {
+	for _, elemInput := range model.CleanDictionarySlice(entry.Get(key)) {
 		if len(me.injectParent) > 0 {
-			elemInput.Set(me.injectParent, copy)
+			elemInput.Set(me.injectParent, entry)
 		}
 		if len(me.injectRoot) > 0 {
-			rootcopy := model.CopyDictionary(context[0])
-			elemInput.Set(me.injectRoot, rootcopy)
+			elemInput.Set(me.injectRoot, model.CopyDictionary(context[0]))
 		}
 		input = append(input, elemInput)
 	}
@@ -85,7 +81,7 @@ func (me MaskEngine) MaskContext(e model.Dictionary, key string, context ...mode
 	if len(me.source) > 0 {
 		over.MDC().Set("config", me.source)
 	}
-	// TODO: possible refactoring
+	// possible refactoring
 	// model.NewSourceFromSlice(input).
 	//			Process(model.NewCounterProcessWithCallback("input-line", 1, updateContext)).
 	//			Process(me.pipeline).
@@ -100,7 +96,7 @@ func (me MaskEngine) MaskContext(e model.Dictionary, key string, context ...mode
 	over.MDC().Set("path", savePath)
 	over.MDC().Set("context", saveContext)
 	if err != nil {
-		return copy, err
+		return entry, err
 	}
 	for _, dict := range result {
 		if len(me.injectParent) > 0 {
@@ -110,8 +106,8 @@ func (me MaskEngine) MaskContext(e model.Dictionary, key string, context ...mode
 			dict.(model.Dictionary).Delete(me.injectRoot)
 		}
 	}
-	copy.Set(key, result)
-	return copy, nil
+	entry.Set(key, result)
+	return entry, nil
 }
 
 // Factory create a mask from a configuration

--- a/pkg/pipe/pipe.go
+++ b/pkg/pipe/pipe.go
@@ -60,7 +60,8 @@ func (me MaskEngine) MaskContext(e model.Dictionary, key string, context ...mode
 	var result []model.Entry
 	input := []model.Dictionary{}
 
-	copy := model.CopyDictionary(e)
+	// copy := model.CopyDictionary(e)
+	copy := e
 
 	value, ok := e.GetValue(key)
 	if !ok || value == nil {
@@ -99,7 +100,7 @@ func (me MaskEngine) MaskContext(e model.Dictionary, key string, context ...mode
 	over.MDC().Set("path", savePath)
 	over.MDC().Set("context", saveContext)
 	if err != nil {
-		return model.NewDictionary(), err
+		return copy, err
 	}
 	for _, dict := range result {
 		if len(me.injectParent) > 0 {

--- a/pkg/weightedchoice/weightedchoice.go
+++ b/pkg/weightedchoice/weightedchoice.go
@@ -75,7 +75,7 @@ func NewMask(list []model.WeightedChoiceType, seed int64, seeder model.Seeder) M
 	rand.Seed(seed) //nolint:staticcheck
 	cs := []Choice{}
 	for k := range list {
-		cs = append(cs, Choice{Item: list[k].Choice, Weight: list[k].Weight})
+		cs = append(cs, Choice{Item: model.CleanTypes(list[k].Choice), Weight: list[k].Weight})
 	}
 	return MaskEngine{NewChooser(seed, cs...), seeder}
 }


### PR DESCRIPTION
Things to test 


```
# keep best of 5 consecutive executions
go test -bench=BenchmarkPimoRunLarge -benchmem -run=^$ -benchtime=10s ./internal/app/pimo/.
```

| Ordered Dict Library | JSON Mashaling Library | ns/op | B/op | allocs/op |
| - | - | - | - | - |
| current | current | 2481264 | 519016 | 1787 |
| github.com/iancoleman/orderedmap | encoding/json | 2436197 | 538111 | 1788 |
| github.com/iancoleman/orderedmap | github.com/goccy/go-json | 2448485 | 538139 | 1788 |
| github.com/iancoleman/orderedmap | github.com/bytedance/sonic | TODO | TODO | TODO |
| github.com/iancoleman/orderedmap | github.com/json-iterator/go | TODO | TODO | TODO |
| github.com/wk8/go-ordered-map/v2 | encoding/json | TODO | TODO | TODO |
| github.com/wk8/go-ordered-map/v2 | github.com/goccy/go-json | 2767586 | 521107 | 2544 |
| github.com/wk8/go-ordered-map/v2 | github.com/bytedance/sonic | TODO | TODO | TODO |
| github.com/wk8/go-ordered-map/v2 | github.com/json-iterator/go | TODO | TODO | TODO |
| github.com/7sDream/geko | encoding/json | TODO | TODO | TODO | TODO |
| github.com/7sDream/geko | github.com/goccy/go-json | TODO | TODO | TODO |
| github.com/7sDream/geko | github.com/bytedance/sonic | TODO | TODO | TODO |
| github.com/7sDream/geko | github.com/json-iterator/go | TODO | TODO | TODO |