### PR TITLE
fix(mock): global seed flag is ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Types of changes
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [1.29.1]
+
+- `Fixed` mock command ignores global seed flag
+
 ## [1.29.0]
 
 - `Added` mask `apply` to externalize masks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Types of changes
 ## [1.29.1]
 
 - `Fixed` mock command ignores global seed flag
+- `Fixed` missing flag `buffer-size` in commands `mock`, `xml` and `play`
 
 ## [1.29.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ Types of changes
 ## [1.29.1]
 
 - `Fixed` mock command ignores global seed flag
-- `Fixed` missing flag `buffer-size` in commands `mock`, `xml` and `play`
+- `Fixed` missing flag `buffer-size` in `mock`, `xml` and `play` commands
+- `Fixed` missing flag `load-cache` in `mock` command
+- `Fixed` remove unused flags from `mock`, `xml`, `parquet`, `jsonschema`, `flow` and `play` commands
 
 ## [1.29.0]
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ You can use [LINO](https://github.com/CGI-FR/LINO) to extract sample data from a
 You can also generate data with a simple yaml configuration file.
 
 **Capabilities**
+
 - credibility : generated data is not distinguishable from real data
 - data synthesis : generate data from nothing
 - data masking, including
@@ -163,6 +164,7 @@ The following types of masks can be used :
   * [`fluxUri`](#fluxuri) is to replace by a sequence of values defined in an external resource.
   * [`replacement`](#replacement) is to mask a data with another data from the jsonline.
   * [`pipe`](#pipe) is a mask to handle complex nested array structures, it can read an array as an object stream and process it with a sub-pipeline.
+  * [`apply`](#apply) process selected data with a sub-pipeline.
   * [`luhn`](#luhn) can generate valid numbers using the Luhn algorithm (e.g. french SIRET or SIREN).
   * [`markov`](#markov) can generate pseudo text based on a sample text.
   * [`findInCSV`](#findincsv) get one or multiple csv lines which matched with Json entry value from CSV files.
@@ -925,6 +927,24 @@ masking:
 ```
 
 Be sure to check [demo](demo/demo8) to get more details about this mask.
+
+[Return to list of masks](#possible-masks)
+
+### Apply
+
+[![Try it](https://img.shields.io/badge/-Try%20it%20in%20PIMO%20Play-brightgreen)](https://cgi-fr.github.io/pimo-play/#c=G4UwTgzglg9gdgLgAQCICMKBQBbAhhAayjgHMFMkkBaJCEAGxAGMAXGMcyrpAKwngAOuFgAtkKKACNccLNzyFO3JLgED6ATyXKkAVzBRxAOgD09KWFxgNJhUVJUpMoxuz0sQA&i=N4KABGBECWBGCGA7SAuKkQF8g)
+
+This mask helps you organize your masking configuration in different files, enablig reuse and mutualisation of masks.
+
+```yaml
+version: "1"
+masking:
+  - selector:
+      jsonpath: "iban"
+    mask:
+      apply:
+        uri: "./library/masking-iban.yml" # list of mask to apply on iban is declared in an external masking file
+```
 
 [Return to list of masks](#possible-masks)
 

--- a/cmd/pimo/flags.go
+++ b/cmd/pimo/flags.go
@@ -1,0 +1,75 @@
+// Copyright (C) 2024 CGI France
+//
+// This file is part of PIMO.
+//
+// PIMO is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// PIMO is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with PIMO.  If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import "github.com/spf13/cobra"
+
+type flag[T any] struct {
+	name      string // Name of the flag
+	shorthand string // Optional short name
+	variable  *T     // Pointer to the variable
+	usage     string // Description of the flag
+}
+
+// flags
+//
+//nolint:gochecknoglobals
+var maxBufferCapacity int
+
+var flagBufferSize = flag[int]{name: "buffer-size", variable: &maxBufferCapacity, usage: "buffer size in kB to load data from uri for each line"}
+
+func addFlag[T any](cmd *cobra.Command, flag flag[T]) {
+	switch typedVar := any(*flag.variable).(type) {
+	case int:
+		if len(flag.shorthand) > 0 {
+			cmd.Flags().IntVarP(&typedVar, flag.name, flag.shorthand, typedVar, flag.usage)
+		} else {
+			cmd.Flags().IntVar(&typedVar, flag.name, typedVar, flag.usage)
+		}
+	case bool:
+		if len(flag.shorthand) > 0 {
+			cmd.Flags().BoolVarP(&typedVar, flag.name, flag.shorthand, typedVar, flag.usage)
+		} else {
+			cmd.Flags().BoolVar(&typedVar, flag.name, typedVar, flag.usage)
+		}
+	case string:
+		if len(flag.shorthand) > 0 {
+			cmd.Flags().StringVarP(&typedVar, flag.name, flag.shorthand, typedVar, flag.usage)
+		} else {
+			cmd.Flags().StringVar(&typedVar, flag.name, typedVar, flag.usage)
+		}
+	case int64:
+		if len(flag.shorthand) > 0 {
+			cmd.Flags().Int64VarP(&typedVar, flag.name, flag.shorthand, typedVar, flag.usage)
+		} else {
+			cmd.Flags().Int64Var(&typedVar, flag.name, typedVar, flag.usage)
+		}
+	case map[string]string:
+		if len(flag.shorthand) > 0 {
+			cmd.Flags().StringToStringVarP(&typedVar, flag.name, flag.shorthand, typedVar, flag.usage)
+		} else {
+			cmd.Flags().StringToStringVar(&typedVar, flag.name, typedVar, flag.usage)
+		}
+	case []string:
+		if len(flag.shorthand) > 0 {
+			cmd.Flags().StringArrayVarP(&typedVar, flag.name, flag.shorthand, typedVar, flag.usage)
+		} else {
+			cmd.Flags().StringArrayVar(&typedVar, flag.name, typedVar, flag.usage)
+		}
+	}
+}

--- a/cmd/pimo/flags.go
+++ b/cmd/pimo/flags.go
@@ -42,6 +42,8 @@ var (
 	iteration         = 1
 	repeatUntil       = ""
 	repeatWhile       = ""
+	seedValue         = int64(0)
+	serve             = ""
 )
 
 var (
@@ -57,6 +59,8 @@ var (
 	flagRepeat        = flag[int]{name: "repeat", shorthand: "r", variable: &iteration, usage: "number of iteration to mask each input"}
 	flagRepeatUntil   = flag[string]{name: "repeat-until", variable: &repeatUntil, usage: "mask each input repeatedly until the given condition is met"}
 	flagRepeatWhile   = flag[string]{name: "repeat-while", variable: &repeatWhile, usage: "mask each input repeatedly while the given condition is met"}
+	flagSeed          = flag[int64]{name: "seed", shorthand: "s", variable: &seedValue, usage: "set global seed"}
+	flagServe         = flag[string]{name: "serve", variable: &serve, usage: "listen/respond to HTTP interface and port instead of stdin/stdout, <ip>:<port> or :<port> to listen to all local networks"}
 )
 
 func addFlag[T any](cmd *cobra.Command, flag flag[T]) {

--- a/cmd/pimo/flags.go
+++ b/cmd/pimo/flags.go
@@ -17,7 +17,11 @@
 
 package main
 
-import "github.com/spf13/cobra"
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
 
 type flag[T any] struct {
 	name      string // Name of the flag
@@ -30,44 +34,50 @@ type flag[T any] struct {
 //
 //nolint:gochecknoglobals
 var (
-	maxBufferCapacity = 64
-	catchErrors       = ""
-	maskingFile       = "masking.yml"
-	mockConfigFile    = "routes.yaml"
-	cachesToDump      = map[string]string{}
-	cachesToLoad      = map[string]string{}
-	emptyInput        = false
-	maskingOneLiner   = []string{}
-	profiling         = ""
-	iteration         = 1
-	repeatUntil       = ""
-	repeatWhile       = ""
-	seedValue         = int64(0)
-	serve             = ""
-	skipLineOnError   = false
-	skipFieldOnError  = false
-	skipLogFile       = ""
+	maxBufferCapacity     = 64
+	catchErrors           = ""
+	maskingFile           = "masking.yml"
+	mockConfigFile        = "routes.yaml"
+	cachesToDump          = map[string]string{}
+	cachesToLoad          = map[string]string{}
+	emptyInput            = false
+	maskingOneLiner       = []string{}
+	profiling             = ""
+	iteration             = 1
+	repeatUntil           = ""
+	repeatWhile           = ""
+	seedValue             = int64(0)
+	serve                 = ""
+	skipLineOnError       = false
+	skipFieldOnError      = false
+	skipLogFile           = ""
+	statisticsDestination = os.Getenv("PIMO_STATS_URL")
+	statsTemplate         = os.Getenv("PIMO_STATS_TEMPLATE")
+	xmlSubscriberName     = map[string]string{}
 )
 
 //nolint:gochecknoglobals
 var (
-	flagBufferSize       = flag[int]{name: "buffer-size", variable: &maxBufferCapacity, usage: "buffer size in kB to load data from uri for each line"}
-	flagCatchErrors      = flag[string]{name: "catch-errors", shorthand: "e", variable: &catchErrors, usage: "catch errors and write line in file, same as using skip-field-on-error + skip-log-file"}
-	flagConfigMasking    = flag[string]{name: "config", shorthand: "c", variable: &maskingFile, usage: "name and location of the masking config file"}
-	flagConfigRoute      = flag[string]{name: "config", shorthand: "c", variable: &mockConfigFile, usage: "name and location of the routes config file"}
-	flagCachesToDump     = flag[map[string]string]{name: "dump-cache", variable: &cachesToDump, usage: "path for dumping cache into file"}
-	flagCachesToLoad     = flag[map[string]string]{name: "load-cache", variable: &cachesToLoad, usage: "path for loading cache from file"}
-	flagEmptyInput       = flag[bool]{name: "empty-input", variable: &emptyInput, usage: "generate data without any input, to use with repeat flag"}
-	flagMaskOneLiner     = flag[[]string]{name: "mask", shorthand: "m", variable: &maskingOneLiner, usage: "one liner masking"}
-	flagProfiling        = flag[string]{name: "pprof", variable: &profiling, usage: "create a pprof file - use 'cpu' to create a CPU pprof file or 'mem' to create an memory pprof file"}
-	flagRepeat           = flag[int]{name: "repeat", shorthand: "r", variable: &iteration, usage: "number of iteration to mask each input"}
-	flagRepeatUntil      = flag[string]{name: "repeat-until", variable: &repeatUntil, usage: "mask each input repeatedly until the given condition is met"}
-	flagRepeatWhile      = flag[string]{name: "repeat-while", variable: &repeatWhile, usage: "mask each input repeatedly while the given condition is met"}
-	flagSeed             = flag[int64]{name: "seed", shorthand: "s", variable: &seedValue, usage: "set global seed"}
-	flagServe            = flag[string]{name: "serve", variable: &serve, usage: "listen/respond to HTTP interface and port instead of stdin/stdout, <ip>:<port> or :<port> to listen to all local networks"}
-	flagSkipLineOnError  = flag[bool]{name: "skip-line-on-error", variable: &skipLineOnError, usage: "skip a line if an error occurs while masking a field"}
-	flagSkipFieldOnError = flag[bool]{name: "skip-field-on-error", variable: &skipFieldOnError, usage: "remove a field if an error occurs while masking this field"}
-	flagSkipLogFile      = flag[string]{name: "skip-log-file", variable: &skipLogFile, usage: "skipped lines will be written to this log file"}
+	flagBufferSize        = flag[int]{name: "buffer-size", variable: &maxBufferCapacity, usage: "buffer size in kB to load data from uri for each line"}
+	flagCatchErrors       = flag[string]{name: "catch-errors", shorthand: "e", variable: &catchErrors, usage: "catch errors and write line in file, same as using skip-field-on-error + skip-log-file"}
+	flagConfigMasking     = flag[string]{name: "config", shorthand: "c", variable: &maskingFile, usage: "name and location of the masking config file"}
+	flagConfigRoute       = flag[string]{name: "config", shorthand: "c", variable: &mockConfigFile, usage: "name and location of the routes config file"}
+	flagCachesToDump      = flag[map[string]string]{name: "dump-cache", variable: &cachesToDump, usage: "path for dumping cache into file"}
+	flagCachesToLoad      = flag[map[string]string]{name: "load-cache", variable: &cachesToLoad, usage: "path for loading cache from file"}
+	flagEmptyInput        = flag[bool]{name: "empty-input", variable: &emptyInput, usage: "generate data without any input, to use with repeat flag"}
+	flagMaskOneLiner      = flag[[]string]{name: "mask", shorthand: "m", variable: &maskingOneLiner, usage: "one liner masking"}
+	flagProfiling         = flag[string]{name: "pprof", variable: &profiling, usage: "create a pprof file - use 'cpu' to create a CPU pprof file or 'mem' to create an memory pprof file"}
+	flagRepeat            = flag[int]{name: "repeat", shorthand: "r", variable: &iteration, usage: "number of iteration to mask each input"}
+	flagRepeatUntil       = flag[string]{name: "repeat-until", variable: &repeatUntil, usage: "mask each input repeatedly until the given condition is met"}
+	flagRepeatWhile       = flag[string]{name: "repeat-while", variable: &repeatWhile, usage: "mask each input repeatedly while the given condition is met"}
+	flagSeed              = flag[int64]{name: "seed", shorthand: "s", variable: &seedValue, usage: "set global seed"}
+	flagServe             = flag[string]{name: "serve", variable: &serve, usage: "listen/respond to HTTP interface and port instead of stdin/stdout, <ip>:<port> or :<port> to listen to all local networks"}
+	flagSkipLineOnError   = flag[bool]{name: "skip-line-on-error", variable: &skipLineOnError, usage: "skip a line if an error occurs while masking a field"}
+	flagSkipFieldOnError  = flag[bool]{name: "skip-field-on-error", variable: &skipFieldOnError, usage: "remove a field if an error occurs while masking this field"}
+	flagSkipLogFile       = flag[string]{name: "skip-log-file", variable: &skipLogFile, usage: "skipped lines will be written to this log file"}
+	flagStatsDestination  = flag[string]{name: "stats", variable: &statisticsDestination, usage: "generate execution statistics in the specified dump file"}
+	flagStatsTemplate     = flag[string]{name: "statsTemplate", variable: &statsTemplate, usage: "template string to format stats (to include them you have to specify them as `{{ .Stats }}` like `{\"software\":\"PIMO\",\"stats\":{{ .Stats }}}`)"}
+	flagXMLSubscriberName = flag[map[string]string]{name: "subscriber", variable: &xmlSubscriberName, usage: "name of element to mask"}
 )
 
 func addFlag[T any](cmd *cobra.Command, flag flag[T]) {

--- a/cmd/pimo/flags.go
+++ b/cmd/pimo/flags.go
@@ -64,42 +64,42 @@ var (
 )
 
 func addFlag[T any](cmd *cobra.Command, flag flag[T]) {
-	switch typedVar := any(*flag.variable).(type) {
-	case int:
+	switch variable := any(flag.variable).(type) {
+	case *int:
 		if len(flag.shorthand) > 0 {
-			cmd.Flags().IntVarP(&typedVar, flag.name, flag.shorthand, typedVar, flag.usage)
+			cmd.Flags().IntVarP(variable, flag.name, flag.shorthand, *variable, flag.usage)
 		} else {
-			cmd.Flags().IntVar(&typedVar, flag.name, typedVar, flag.usage)
+			cmd.Flags().IntVar(variable, flag.name, *variable, flag.usage)
 		}
-	case bool:
+	case *bool:
 		if len(flag.shorthand) > 0 {
-			cmd.Flags().BoolVarP(&typedVar, flag.name, flag.shorthand, typedVar, flag.usage)
+			cmd.Flags().BoolVarP(variable, flag.name, flag.shorthand, *variable, flag.usage)
 		} else {
-			cmd.Flags().BoolVar(&typedVar, flag.name, typedVar, flag.usage)
+			cmd.Flags().BoolVar(variable, flag.name, *variable, flag.usage)
 		}
-	case string:
+	case *string:
 		if len(flag.shorthand) > 0 {
-			cmd.Flags().StringVarP(&typedVar, flag.name, flag.shorthand, typedVar, flag.usage)
+			cmd.Flags().StringVarP(variable, flag.name, flag.shorthand, *variable, flag.usage)
 		} else {
-			cmd.Flags().StringVar(&typedVar, flag.name, typedVar, flag.usage)
+			cmd.Flags().StringVar(variable, flag.name, *variable, flag.usage)
 		}
-	case int64:
+	case *int64:
 		if len(flag.shorthand) > 0 {
-			cmd.Flags().Int64VarP(&typedVar, flag.name, flag.shorthand, typedVar, flag.usage)
+			cmd.Flags().Int64VarP(variable, flag.name, flag.shorthand, *variable, flag.usage)
 		} else {
-			cmd.Flags().Int64Var(&typedVar, flag.name, typedVar, flag.usage)
+			cmd.Flags().Int64Var(variable, flag.name, *variable, flag.usage)
 		}
-	case map[string]string:
+	case *map[string]string:
 		if len(flag.shorthand) > 0 {
-			cmd.Flags().StringToStringVarP(&typedVar, flag.name, flag.shorthand, typedVar, flag.usage)
+			cmd.Flags().StringToStringVarP(variable, flag.name, flag.shorthand, *variable, flag.usage)
 		} else {
-			cmd.Flags().StringToStringVar(&typedVar, flag.name, typedVar, flag.usage)
+			cmd.Flags().StringToStringVar(variable, flag.name, *variable, flag.usage)
 		}
-	case []string:
+	case *[]string:
 		if len(flag.shorthand) > 0 {
-			cmd.Flags().StringArrayVarP(&typedVar, flag.name, flag.shorthand, typedVar, flag.usage)
+			cmd.Flags().StringArrayVarP(variable, flag.name, flag.shorthand, *variable, flag.usage)
 		} else {
-			cmd.Flags().StringArrayVar(&typedVar, flag.name, typedVar, flag.usage)
+			cmd.Flags().StringArrayVar(variable, flag.name, *variable, flag.usage)
 		}
 	}
 }

--- a/cmd/pimo/flags.go
+++ b/cmd/pimo/flags.go
@@ -37,6 +37,8 @@ var (
 	cachesToDump      = map[string]string{}
 	cachesToLoad      = map[string]string{}
 	emptyInput        = false
+	maskingOneLiner   = []string{}
+	profiling         = ""
 )
 
 var (
@@ -47,6 +49,8 @@ var (
 	flagCachesToDump  = flag[map[string]string]{name: "dump-cache", variable: &cachesToDump, usage: "path for dumping cache into file"}
 	flagCachesToLoad  = flag[map[string]string]{name: "load-cache", variable: &cachesToLoad, usage: "path for loading cache from file"}
 	flagEmptyInput    = flag[bool]{name: "empty-input", variable: &emptyInput, usage: "generate data without any input, to use with repeat flag"}
+	flagMaskOneLiner  = flag[[]string]{name: "mask", shorthand: "m", variable: &maskingOneLiner, usage: "one liner masking"}
+	flagProfiling     = flag[string]{name: "pprof", variable: &profiling, usage: "create a pprof file - use 'cpu' to create a CPU pprof file or 'mem' to create an memory pprof file"}
 )
 
 func addFlag[T any](cmd *cobra.Command, flag flag[T]) {

--- a/cmd/pimo/flags.go
+++ b/cmd/pimo/flags.go
@@ -29,9 +29,19 @@ type flag[T any] struct {
 // flags
 //
 //nolint:gochecknoglobals
-var maxBufferCapacity int
+var (
+	maxBufferCapacity int
+	catchErrors       string
+	maskingFile       = "masking.yml"
+	mockConfigFile    = "routes.yaml"
+)
 
-var flagBufferSize = flag[int]{name: "buffer-size", variable: &maxBufferCapacity, usage: "buffer size in kB to load data from uri for each line"}
+var (
+	flagBufferSize    = flag[int]{name: "buffer-size", variable: &maxBufferCapacity, usage: "buffer size in kB to load data from uri for each line"}
+	flagCatchErrors   = flag[string]{name: "catch-errors", variable: &catchErrors, usage: "catch errors and write line in file, same as using skip-field-on-error + skip-log-file"}
+	flagConfigMasking = flag[string]{name: "config", variable: &maskingFile, usage: "name and location of the masking config file"}
+	flagConfigRoute   = flag[string]{name: "config", variable: &mockConfigFile, usage: "name and location of the routes config file"}
+)
 
 func addFlag[T any](cmd *cobra.Command, flag flag[T]) {
 	switch typedVar := any(*flag.variable).(type) {

--- a/cmd/pimo/flags.go
+++ b/cmd/pimo/flags.go
@@ -26,21 +26,27 @@ type flag[T any] struct {
 	usage     string // Description of the flag
 }
 
-// flags
+// flags with default values
 //
 //nolint:gochecknoglobals
 var (
-	maxBufferCapacity int
-	catchErrors       string
+	maxBufferCapacity = 64
+	catchErrors       = ""
 	maskingFile       = "masking.yml"
 	mockConfigFile    = "routes.yaml"
+	cachesToDump      = map[string]string{}
+	cachesToLoad      = map[string]string{}
+	emptyInput        = false
 )
 
 var (
 	flagBufferSize    = flag[int]{name: "buffer-size", variable: &maxBufferCapacity, usage: "buffer size in kB to load data from uri for each line"}
-	flagCatchErrors   = flag[string]{name: "catch-errors", variable: &catchErrors, usage: "catch errors and write line in file, same as using skip-field-on-error + skip-log-file"}
-	flagConfigMasking = flag[string]{name: "config", variable: &maskingFile, usage: "name and location of the masking config file"}
-	flagConfigRoute   = flag[string]{name: "config", variable: &mockConfigFile, usage: "name and location of the routes config file"}
+	flagCatchErrors   = flag[string]{name: "catch-errors", shorthand: "e", variable: &catchErrors, usage: "catch errors and write line in file, same as using skip-field-on-error + skip-log-file"}
+	flagConfigMasking = flag[string]{name: "config", shorthand: "c", variable: &maskingFile, usage: "name and location of the masking config file"}
+	flagConfigRoute   = flag[string]{name: "config", shorthand: "c", variable: &mockConfigFile, usage: "name and location of the routes config file"}
+	flagCachesToDump  = flag[map[string]string]{name: "dump-cache", variable: &cachesToDump, usage: "path for dumping cache into file"}
+	flagCachesToLoad  = flag[map[string]string]{name: "load-cache", variable: &cachesToLoad, usage: "path for loading cache from file"}
+	flagEmptyInput    = flag[bool]{name: "empty-input", variable: &emptyInput, usage: "generate data without any input, to use with repeat flag"}
 )
 
 func addFlag[T any](cmd *cobra.Command, flag flag[T]) {

--- a/cmd/pimo/flags.go
+++ b/cmd/pimo/flags.go
@@ -44,23 +44,30 @@ var (
 	repeatWhile       = ""
 	seedValue         = int64(0)
 	serve             = ""
+	skipLineOnError   = false
+	skipFieldOnError  = false
+	skipLogFile       = ""
 )
 
+//nolint:gochecknoglobals
 var (
-	flagBufferSize    = flag[int]{name: "buffer-size", variable: &maxBufferCapacity, usage: "buffer size in kB to load data from uri for each line"}
-	flagCatchErrors   = flag[string]{name: "catch-errors", shorthand: "e", variable: &catchErrors, usage: "catch errors and write line in file, same as using skip-field-on-error + skip-log-file"}
-	flagConfigMasking = flag[string]{name: "config", shorthand: "c", variable: &maskingFile, usage: "name and location of the masking config file"}
-	flagConfigRoute   = flag[string]{name: "config", shorthand: "c", variable: &mockConfigFile, usage: "name and location of the routes config file"}
-	flagCachesToDump  = flag[map[string]string]{name: "dump-cache", variable: &cachesToDump, usage: "path for dumping cache into file"}
-	flagCachesToLoad  = flag[map[string]string]{name: "load-cache", variable: &cachesToLoad, usage: "path for loading cache from file"}
-	flagEmptyInput    = flag[bool]{name: "empty-input", variable: &emptyInput, usage: "generate data without any input, to use with repeat flag"}
-	flagMaskOneLiner  = flag[[]string]{name: "mask", shorthand: "m", variable: &maskingOneLiner, usage: "one liner masking"}
-	flagProfiling     = flag[string]{name: "pprof", variable: &profiling, usage: "create a pprof file - use 'cpu' to create a CPU pprof file or 'mem' to create an memory pprof file"}
-	flagRepeat        = flag[int]{name: "repeat", shorthand: "r", variable: &iteration, usage: "number of iteration to mask each input"}
-	flagRepeatUntil   = flag[string]{name: "repeat-until", variable: &repeatUntil, usage: "mask each input repeatedly until the given condition is met"}
-	flagRepeatWhile   = flag[string]{name: "repeat-while", variable: &repeatWhile, usage: "mask each input repeatedly while the given condition is met"}
-	flagSeed          = flag[int64]{name: "seed", shorthand: "s", variable: &seedValue, usage: "set global seed"}
-	flagServe         = flag[string]{name: "serve", variable: &serve, usage: "listen/respond to HTTP interface and port instead of stdin/stdout, <ip>:<port> or :<port> to listen to all local networks"}
+	flagBufferSize       = flag[int]{name: "buffer-size", variable: &maxBufferCapacity, usage: "buffer size in kB to load data from uri for each line"}
+	flagCatchErrors      = flag[string]{name: "catch-errors", shorthand: "e", variable: &catchErrors, usage: "catch errors and write line in file, same as using skip-field-on-error + skip-log-file"}
+	flagConfigMasking    = flag[string]{name: "config", shorthand: "c", variable: &maskingFile, usage: "name and location of the masking config file"}
+	flagConfigRoute      = flag[string]{name: "config", shorthand: "c", variable: &mockConfigFile, usage: "name and location of the routes config file"}
+	flagCachesToDump     = flag[map[string]string]{name: "dump-cache", variable: &cachesToDump, usage: "path for dumping cache into file"}
+	flagCachesToLoad     = flag[map[string]string]{name: "load-cache", variable: &cachesToLoad, usage: "path for loading cache from file"}
+	flagEmptyInput       = flag[bool]{name: "empty-input", variable: &emptyInput, usage: "generate data without any input, to use with repeat flag"}
+	flagMaskOneLiner     = flag[[]string]{name: "mask", shorthand: "m", variable: &maskingOneLiner, usage: "one liner masking"}
+	flagProfiling        = flag[string]{name: "pprof", variable: &profiling, usage: "create a pprof file - use 'cpu' to create a CPU pprof file or 'mem' to create an memory pprof file"}
+	flagRepeat           = flag[int]{name: "repeat", shorthand: "r", variable: &iteration, usage: "number of iteration to mask each input"}
+	flagRepeatUntil      = flag[string]{name: "repeat-until", variable: &repeatUntil, usage: "mask each input repeatedly until the given condition is met"}
+	flagRepeatWhile      = flag[string]{name: "repeat-while", variable: &repeatWhile, usage: "mask each input repeatedly while the given condition is met"}
+	flagSeed             = flag[int64]{name: "seed", shorthand: "s", variable: &seedValue, usage: "set global seed"}
+	flagServe            = flag[string]{name: "serve", variable: &serve, usage: "listen/respond to HTTP interface and port instead of stdin/stdout, <ip>:<port> or :<port> to listen to all local networks"}
+	flagSkipLineOnError  = flag[bool]{name: "skip-line-on-error", variable: &skipLineOnError, usage: "skip a line if an error occurs while masking a field"}
+	flagSkipFieldOnError = flag[bool]{name: "skip-field-on-error", variable: &skipFieldOnError, usage: "remove a field if an error occurs while masking this field"}
+	flagSkipLogFile      = flag[string]{name: "skip-log-file", variable: &skipLogFile, usage: "skipped lines will be written to this log file"}
 )
 
 func addFlag[T any](cmd *cobra.Command, flag flag[T]) {

--- a/cmd/pimo/flags.go
+++ b/cmd/pimo/flags.go
@@ -39,6 +39,9 @@ var (
 	emptyInput        = false
 	maskingOneLiner   = []string{}
 	profiling         = ""
+	iteration         = 1
+	repeatUntil       = ""
+	repeatWhile       = ""
 )
 
 var (
@@ -51,6 +54,9 @@ var (
 	flagEmptyInput    = flag[bool]{name: "empty-input", variable: &emptyInput, usage: "generate data without any input, to use with repeat flag"}
 	flagMaskOneLiner  = flag[[]string]{name: "mask", shorthand: "m", variable: &maskingOneLiner, usage: "one liner masking"}
 	flagProfiling     = flag[string]{name: "pprof", variable: &profiling, usage: "create a pprof file - use 'cpu' to create a CPU pprof file or 'mem' to create an memory pprof file"}
+	flagRepeat        = flag[int]{name: "repeat", shorthand: "r", variable: &iteration, usage: "number of iteration to mask each input"}
+	flagRepeatUntil   = flag[string]{name: "repeat-until", variable: &repeatUntil, usage: "mask each input repeatedly until the given condition is met"}
+	flagRepeatWhile   = flag[string]{name: "repeat-while", variable: &repeatWhile, usage: "mask each input repeatedly while the given condition is met"}
 )
 
 func addFlag[T any](cmd *cobra.Command, flag flag[T]) {

--- a/cmd/pimo/main.go
+++ b/cmd/pimo/main.go
@@ -56,13 +56,11 @@ var (
 	skipLineOnError       bool
 	skipFieldOnError      bool
 	skipLogFile           string
-	seedValue             int64
 	statisticsDestination string
 	statsTemplate         string
 	statsDestinationEnv   = os.Getenv("PIMO_STATS_URL")
 	statsTemplateEnv      = os.Getenv("PIMO_STATS_TEMPLATE")
 	xmlSubscriberName     map[string]string
-	serve                 string
 	parquetInput          string
 	parquetOutput         string
 )
@@ -94,10 +92,8 @@ There is NO WARRANTY, to the extent permitted by law.`, version, commit, buildDa
 	rootCmd.PersistentFlags().BoolVar(&skipLineOnError, "skip-line-on-error", false, "skip a line if an error occurs while masking a field")
 	rootCmd.PersistentFlags().BoolVar(&skipFieldOnError, "skip-field-on-error", false, "remove a field if an error occurs while masking this field")
 	rootCmd.PersistentFlags().StringVar(&skipLogFile, "skip-log-file", "", "skipped lines will be written to this log file")
-	rootCmd.Flags().Int64VarP(&seedValue, "seed", "s", 0, "set seed")
 	rootCmd.PersistentFlags().StringVar(&statisticsDestination, "stats", statsDestinationEnv, "generate execution statistics in the specified dump file")
 	rootCmd.PersistentFlags().StringVar(&statsTemplate, "statsTemplate", statsTemplateEnv, "template string to format stats (to include them you have to specify them as `{{ .Stats }}` like `{\"software\":\"PIMO\",\"stats\":{{ .Stats }}}`)")
-	rootCmd.Flags().StringVar(&serve, "serve", "", "listen/respond to HTTP interface and port instead of stdin/stdout, <ip>:<port> or :<port> to listen to all local networks")
 
 	addFlag(rootCmd, flagBufferSize)
 	addFlag(rootCmd, flagCatchErrors)
@@ -110,6 +106,8 @@ There is NO WARRANTY, to the extent permitted by law.`, version, commit, buildDa
 	addFlag(rootCmd, flagRepeat)
 	addFlag(rootCmd, flagRepeatUntil)
 	addFlag(rootCmd, flagRepeatWhile)
+	addFlag(rootCmd, flagSeed)
+	addFlag(rootCmd, flagServe)
 
 	rootCmd.AddCommand(&cobra.Command{
 		Use: "jsonschema",
@@ -180,12 +178,12 @@ There is NO WARRANTY, to the extent permitted by law.`, version, commit, buildDa
 		},
 	}
 	xmlCmd.Flags().StringToStringVar(&xmlSubscriberName, "subscriber", map[string]string{}, "name of element to mask")
-	xmlCmd.Flags().Int64VarP(&seedValue, "seed", "s", 0, "set seed")
 	addFlag(xmlCmd, flagBufferSize)
 	addFlag(xmlCmd, flagCatchErrors)
 	addFlag(xmlCmd, flagCachesToDump)
 	addFlag(xmlCmd, flagCachesToLoad)
 	// addFlag(xmlCmd, flagProfiling) //could use
+	addFlag(xmlCmd, flagSeed)
 	rootCmd.AddCommand(xmlCmd)
 
 	// Add command for parquet transformer
@@ -205,7 +203,6 @@ There is NO WARRANTY, to the extent permitted by law.`, version, commit, buildDa
 			run(cmd)
 		},
 	}
-	parquetCmd.Flags().Int64VarP(&seedValue, "seed", "s", 0, "set seed")
 	addFlag(parquetCmd, flagBufferSize)
 	addFlag(parquetCmd, flagCatchErrors)
 	addFlag(parquetCmd, flagConfigMasking)
@@ -213,6 +210,7 @@ There is NO WARRANTY, to the extent permitted by law.`, version, commit, buildDa
 	addFlag(parquetCmd, flagCachesToLoad)
 	addFlag(parquetCmd, flagMaskOneLiner)
 	addFlag(parquetCmd, flagProfiling)
+	addFlag(parquetCmd, flagSeed)
 	rootCmd.AddCommand(parquetCmd)
 
 	flowCmd := &cobra.Command{

--- a/cmd/pimo/main.go
+++ b/cmd/pimo/main.go
@@ -58,7 +58,6 @@ var (
 	skipFieldOnError      bool
 	skipLogFile           string
 	seedValue             int64
-	maskingOneLiner       []string
 	repeatUntil           string
 	repeatWhile           string
 	statisticsDestination string
@@ -67,7 +66,6 @@ var (
 	statsTemplateEnv      = os.Getenv("PIMO_STATS_TEMPLATE")
 	xmlSubscriberName     map[string]string
 	serve                 string
-	profiling             string
 	parquetInput          string
 	parquetOutput         string
 )
@@ -101,13 +99,11 @@ There is NO WARRANTY, to the extent permitted by law.`, version, commit, buildDa
 	rootCmd.PersistentFlags().BoolVar(&skipFieldOnError, "skip-field-on-error", false, "remove a field if an error occurs while masking this field")
 	rootCmd.PersistentFlags().StringVar(&skipLogFile, "skip-log-file", "", "skipped lines will be written to this log file")
 	rootCmd.Flags().Int64VarP(&seedValue, "seed", "s", 0, "set seed")
-	rootCmd.PersistentFlags().StringArrayVarP(&maskingOneLiner, "mask", "m", []string{}, "one liner masking")
 	rootCmd.PersistentFlags().StringVar(&repeatUntil, "repeat-until", "", "mask each input repeatedly until the given condition is met")
 	rootCmd.PersistentFlags().StringVar(&repeatWhile, "repeat-while", "", "mask each input repeatedly while the given condition is met")
 	rootCmd.PersistentFlags().StringVar(&statisticsDestination, "stats", statsDestinationEnv, "generate execution statistics in the specified dump file")
 	rootCmd.PersistentFlags().StringVar(&statsTemplate, "statsTemplate", statsTemplateEnv, "template string to format stats (to include them you have to specify them as `{{ .Stats }}` like `{\"software\":\"PIMO\",\"stats\":{{ .Stats }}}`)")
 	rootCmd.Flags().StringVar(&serve, "serve", "", "listen/respond to HTTP interface and port instead of stdin/stdout, <ip>:<port> or :<port> to listen to all local networks")
-	rootCmd.Flags().StringVar(&profiling, "pprof", "", "create a pprof file - use 'cpu' to create a CPU pprof file or 'mem' to create an memory pprof file")
 
 	addFlag(rootCmd, flagBufferSize)
 	addFlag(rootCmd, flagCatchErrors)
@@ -115,6 +111,8 @@ There is NO WARRANTY, to the extent permitted by law.`, version, commit, buildDa
 	addFlag(rootCmd, flagCachesToDump)
 	addFlag(rootCmd, flagCachesToLoad)
 	addFlag(rootCmd, flagEmptyInput)
+	addFlag(rootCmd, flagMaskOneLiner)
+	addFlag(rootCmd, flagProfiling)
 
 	rootCmd.AddCommand(&cobra.Command{
 		Use: "jsonschema",
@@ -190,6 +188,7 @@ There is NO WARRANTY, to the extent permitted by law.`, version, commit, buildDa
 	addFlag(xmlCmd, flagCatchErrors)
 	addFlag(xmlCmd, flagCachesToDump)
 	addFlag(xmlCmd, flagCachesToLoad)
+	// addFlag(xmlCmd, flagProfiling) //could use
 	rootCmd.AddCommand(xmlCmd)
 
 	// Add command for parquet transformer
@@ -215,6 +214,8 @@ There is NO WARRANTY, to the extent permitted by law.`, version, commit, buildDa
 	addFlag(parquetCmd, flagConfigMasking)
 	addFlag(parquetCmd, flagCachesToDump)
 	addFlag(parquetCmd, flagCachesToLoad)
+	addFlag(parquetCmd, flagMaskOneLiner)
+	addFlag(parquetCmd, flagProfiling)
 	rootCmd.AddCommand(parquetCmd)
 
 	flowCmd := &cobra.Command{

--- a/cmd/pimo/main.go
+++ b/cmd/pimo/main.go
@@ -54,9 +54,6 @@ var (
 	jsonlog               bool
 	colormode             string
 	iteration             int
-	emptyInput            bool
-	cachesToDump          map[string]string
-	cachesToLoad          map[string]string
 	skipLineOnError       bool
 	skipFieldOnError      bool
 	skipLogFile           string
@@ -100,9 +97,6 @@ There is NO WARRANTY, to the extent permitted by law.`, version, commit, buildDa
 	rootCmd.PersistentFlags().BoolVar(&jsonlog, "log-json", false, "output logs in JSON format")
 	rootCmd.PersistentFlags().StringVar(&colormode, "color", "auto", "use colors in log outputs : yes, no or auto")
 	rootCmd.PersistentFlags().IntVarP(&iteration, "repeat", "r", 1, "number of iteration to mask each input")
-	rootCmd.PersistentFlags().BoolVar(&emptyInput, "empty-input", false, "generate data without any input, to use with repeat flag")
-	rootCmd.PersistentFlags().StringToStringVar(&cachesToDump, "dump-cache", map[string]string{}, "path for dumping cache into file")
-	rootCmd.PersistentFlags().StringToStringVar(&cachesToLoad, "load-cache", map[string]string{}, "path for loading cache from file")
 	rootCmd.PersistentFlags().BoolVar(&skipLineOnError, "skip-line-on-error", false, "skip a line if an error occurs while masking a field")
 	rootCmd.PersistentFlags().BoolVar(&skipFieldOnError, "skip-field-on-error", false, "remove a field if an error occurs while masking this field")
 	rootCmd.PersistentFlags().StringVar(&skipLogFile, "skip-log-file", "", "skipped lines will be written to this log file")
@@ -118,6 +112,9 @@ There is NO WARRANTY, to the extent permitted by law.`, version, commit, buildDa
 	addFlag(rootCmd, flagBufferSize)
 	addFlag(rootCmd, flagCatchErrors)
 	addFlag(rootCmd, flagConfigMasking)
+	addFlag(rootCmd, flagCachesToDump)
+	addFlag(rootCmd, flagCachesToLoad)
+	addFlag(rootCmd, flagEmptyInput)
 
 	rootCmd.AddCommand(&cobra.Command{
 		Use: "jsonschema",
@@ -191,6 +188,8 @@ There is NO WARRANTY, to the extent permitted by law.`, version, commit, buildDa
 	xmlCmd.Flags().Int64VarP(&seedValue, "seed", "s", 0, "set seed")
 	addFlag(xmlCmd, flagBufferSize)
 	addFlag(xmlCmd, flagCatchErrors)
+	addFlag(xmlCmd, flagCachesToDump)
+	addFlag(xmlCmd, flagCachesToLoad)
 	rootCmd.AddCommand(xmlCmd)
 
 	// Add command for parquet transformer
@@ -214,6 +213,8 @@ There is NO WARRANTY, to the extent permitted by law.`, version, commit, buildDa
 	addFlag(parquetCmd, flagBufferSize)
 	addFlag(parquetCmd, flagCatchErrors)
 	addFlag(parquetCmd, flagConfigMasking)
+	addFlag(parquetCmd, flagCachesToDump)
+	addFlag(parquetCmd, flagCachesToLoad)
 	rootCmd.AddCommand(parquetCmd)
 
 	flowCmd := &cobra.Command{

--- a/cmd/pimo/main.go
+++ b/cmd/pimo/main.go
@@ -53,9 +53,6 @@ var (
 	debug                 bool
 	jsonlog               bool
 	colormode             string
-	skipLineOnError       bool
-	skipFieldOnError      bool
-	skipLogFile           string
 	statisticsDestination string
 	statsTemplate         string
 	statsDestinationEnv   = os.Getenv("PIMO_STATS_URL")
@@ -89,9 +86,6 @@ There is NO WARRANTY, to the extent permitted by law.`, version, commit, buildDa
 	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "add debug information to logs (very slow)")
 	rootCmd.PersistentFlags().BoolVar(&jsonlog, "log-json", false, "output logs in JSON format")
 	rootCmd.PersistentFlags().StringVar(&colormode, "color", "auto", "use colors in log outputs : yes, no or auto")
-	rootCmd.PersistentFlags().BoolVar(&skipLineOnError, "skip-line-on-error", false, "skip a line if an error occurs while masking a field")
-	rootCmd.PersistentFlags().BoolVar(&skipFieldOnError, "skip-field-on-error", false, "remove a field if an error occurs while masking this field")
-	rootCmd.PersistentFlags().StringVar(&skipLogFile, "skip-log-file", "", "skipped lines will be written to this log file")
 	rootCmd.PersistentFlags().StringVar(&statisticsDestination, "stats", statsDestinationEnv, "generate execution statistics in the specified dump file")
 	rootCmd.PersistentFlags().StringVar(&statsTemplate, "statsTemplate", statsTemplateEnv, "template string to format stats (to include them you have to specify them as `{{ .Stats }}` like `{\"software\":\"PIMO\",\"stats\":{{ .Stats }}}`)")
 
@@ -108,6 +102,9 @@ There is NO WARRANTY, to the extent permitted by law.`, version, commit, buildDa
 	addFlag(rootCmd, flagRepeatWhile)
 	addFlag(rootCmd, flagSeed)
 	addFlag(rootCmd, flagServe)
+	addFlag(rootCmd, flagSkipFieldOnError)
+	addFlag(rootCmd, flagSkipLineOnError)
+	addFlag(rootCmd, flagSkipLogFile)
 
 	rootCmd.AddCommand(&cobra.Command{
 		Use: "jsonschema",
@@ -184,6 +181,9 @@ There is NO WARRANTY, to the extent permitted by law.`, version, commit, buildDa
 	addFlag(xmlCmd, flagCachesToLoad)
 	// addFlag(xmlCmd, flagProfiling) //could use
 	addFlag(xmlCmd, flagSeed)
+	addFlag(xmlCmd, flagSkipFieldOnError)
+	addFlag(xmlCmd, flagSkipLineOnError)
+	addFlag(xmlCmd, flagSkipLogFile)
 	rootCmd.AddCommand(xmlCmd)
 
 	// Add command for parquet transformer
@@ -211,6 +211,9 @@ There is NO WARRANTY, to the extent permitted by law.`, version, commit, buildDa
 	addFlag(parquetCmd, flagMaskOneLiner)
 	addFlag(parquetCmd, flagProfiling)
 	addFlag(parquetCmd, flagSeed)
+	addFlag(parquetCmd, flagSkipFieldOnError)
+	addFlag(parquetCmd, flagSkipLineOnError)
+	addFlag(parquetCmd, flagSkipLogFile)
 	rootCmd.AddCommand(parquetCmd)
 
 	flowCmd := &cobra.Command{

--- a/cmd/pimo/main.go
+++ b/cmd/pimo/main.go
@@ -104,7 +104,8 @@ There is NO WARRANTY, to the extent permitted by law.`, version, commit, buildDa
 	addFlag(rootCmd, flagStatsTemplate)
 
 	rootCmd.AddCommand(&cobra.Command{
-		Use: "jsonschema",
+		Use:   "jsonschema",
+		Short: "Export schema of masking configuration",
 		Run: func(cmd *cobra.Command, args []string) {
 			initLog()
 			jsonschema, err := pimo.GetJsonSchema()
@@ -218,7 +219,8 @@ There is NO WARRANTY, to the extent permitted by law.`, version, commit, buildDa
 	rootCmd.AddCommand(parquetCmd)
 
 	flowCmd := &cobra.Command{
-		Use: "flow",
+		Use:   "flow",
+		Short: "Export masking configuration as graphviz diagram",
 		Run: func(cmd *cobra.Command, args []string) {
 			initLog()
 			pdef, err := model.LoadPipelineDefinitionFromFile(maskingFile)
@@ -239,7 +241,8 @@ There is NO WARRANTY, to the extent permitted by law.`, version, commit, buildDa
 	playPort := 3010
 	playSecure := false
 	playCmd := &cobra.Command{
-		Use: "play",
+		Use:   "play",
+		Short: "Start local website to play with PIMO",
 		Run: func(cmd *cobra.Command, args []string) {
 			initLog()
 

--- a/cmd/pimo/main.go
+++ b/cmd/pimo/main.go
@@ -42,24 +42,21 @@ import (
 )
 
 // Provisioned by ldflags
-// nolint: gochecknoglobals
+//
+//nolint:gochecknoglobals
 var (
 	version   string
 	commit    string
 	buildDate string
 	builtBy   string
 
-	verbosity             string
-	debug                 bool
-	jsonlog               bool
-	colormode             string
-	statisticsDestination string
-	statsTemplate         string
-	statsDestinationEnv   = os.Getenv("PIMO_STATS_URL")
-	statsTemplateEnv      = os.Getenv("PIMO_STATS_TEMPLATE")
-	xmlSubscriberName     map[string]string
-	parquetInput          string
-	parquetOutput         string
+	verbosity string
+	debug     bool
+	jsonlog   bool
+	colormode string
+
+	parquetInput  string
+	parquetOutput string
 )
 
 func main() {
@@ -86,8 +83,6 @@ There is NO WARRANTY, to the extent permitted by law.`, version, commit, buildDa
 	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "add debug information to logs (very slow)")
 	rootCmd.PersistentFlags().BoolVar(&jsonlog, "log-json", false, "output logs in JSON format")
 	rootCmd.PersistentFlags().StringVar(&colormode, "color", "auto", "use colors in log outputs : yes, no or auto")
-	rootCmd.PersistentFlags().StringVar(&statisticsDestination, "stats", statsDestinationEnv, "generate execution statistics in the specified dump file")
-	rootCmd.PersistentFlags().StringVar(&statsTemplate, "statsTemplate", statsTemplateEnv, "template string to format stats (to include them you have to specify them as `{{ .Stats }}` like `{\"software\":\"PIMO\",\"stats\":{{ .Stats }}}`)")
 
 	addFlag(rootCmd, flagBufferSize)
 	addFlag(rootCmd, flagCatchErrors)
@@ -105,6 +100,8 @@ There is NO WARRANTY, to the extent permitted by law.`, version, commit, buildDa
 	addFlag(rootCmd, flagSkipFieldOnError)
 	addFlag(rootCmd, flagSkipLineOnError)
 	addFlag(rootCmd, flagSkipLogFile)
+	addFlag(rootCmd, flagStatsDestination)
+	addFlag(rootCmd, flagStatsTemplate)
 
 	rootCmd.AddCommand(&cobra.Command{
 		Use: "jsonschema",
@@ -174,7 +171,6 @@ There is NO WARRANTY, to the extent permitted by law.`, version, commit, buildDa
 			}
 		},
 	}
-	xmlCmd.Flags().StringToStringVar(&xmlSubscriberName, "subscriber", map[string]string{}, "name of element to mask")
 	addFlag(xmlCmd, flagBufferSize)
 	addFlag(xmlCmd, flagCatchErrors)
 	addFlag(xmlCmd, flagCachesToDump)
@@ -184,6 +180,9 @@ There is NO WARRANTY, to the extent permitted by law.`, version, commit, buildDa
 	addFlag(xmlCmd, flagSkipFieldOnError)
 	addFlag(xmlCmd, flagSkipLineOnError)
 	addFlag(xmlCmd, flagSkipLogFile)
+	// addFlag(xmlCmd, flagStatsDestination) // could use
+	// addFlag(xmlCmd, flagStatsTemplate)    // could use
+	addFlag(xmlCmd, flagXMLSubscriberName)
 	rootCmd.AddCommand(xmlCmd)
 
 	// Add command for parquet transformer
@@ -214,6 +213,8 @@ There is NO WARRANTY, to the extent permitted by law.`, version, commit, buildDa
 	addFlag(parquetCmd, flagSkipFieldOnError)
 	addFlag(parquetCmd, flagSkipLineOnError)
 	addFlag(parquetCmd, flagSkipLogFile)
+	addFlag(parquetCmd, flagStatsDestination)
+	addFlag(parquetCmd, flagStatsTemplate)
 	rootCmd.AddCommand(parquetCmd)
 
 	flowCmd := &cobra.Command{

--- a/cmd/pimo/main.go
+++ b/cmd/pimo/main.go
@@ -53,13 +53,10 @@ var (
 	debug                 bool
 	jsonlog               bool
 	colormode             string
-	iteration             int
 	skipLineOnError       bool
 	skipFieldOnError      bool
 	skipLogFile           string
 	seedValue             int64
-	repeatUntil           string
-	repeatWhile           string
 	statisticsDestination string
 	statsTemplate         string
 	statsDestinationEnv   = os.Getenv("PIMO_STATS_URL")
@@ -94,13 +91,10 @@ There is NO WARRANTY, to the extent permitted by law.`, version, commit, buildDa
 	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "add debug information to logs (very slow)")
 	rootCmd.PersistentFlags().BoolVar(&jsonlog, "log-json", false, "output logs in JSON format")
 	rootCmd.PersistentFlags().StringVar(&colormode, "color", "auto", "use colors in log outputs : yes, no or auto")
-	rootCmd.PersistentFlags().IntVarP(&iteration, "repeat", "r", 1, "number of iteration to mask each input")
 	rootCmd.PersistentFlags().BoolVar(&skipLineOnError, "skip-line-on-error", false, "skip a line if an error occurs while masking a field")
 	rootCmd.PersistentFlags().BoolVar(&skipFieldOnError, "skip-field-on-error", false, "remove a field if an error occurs while masking this field")
 	rootCmd.PersistentFlags().StringVar(&skipLogFile, "skip-log-file", "", "skipped lines will be written to this log file")
 	rootCmd.Flags().Int64VarP(&seedValue, "seed", "s", 0, "set seed")
-	rootCmd.PersistentFlags().StringVar(&repeatUntil, "repeat-until", "", "mask each input repeatedly until the given condition is met")
-	rootCmd.PersistentFlags().StringVar(&repeatWhile, "repeat-while", "", "mask each input repeatedly while the given condition is met")
 	rootCmd.PersistentFlags().StringVar(&statisticsDestination, "stats", statsDestinationEnv, "generate execution statistics in the specified dump file")
 	rootCmd.PersistentFlags().StringVar(&statsTemplate, "statsTemplate", statsTemplateEnv, "template string to format stats (to include them you have to specify them as `{{ .Stats }}` like `{\"software\":\"PIMO\",\"stats\":{{ .Stats }}}`)")
 	rootCmd.Flags().StringVar(&serve, "serve", "", "listen/respond to HTTP interface and port instead of stdin/stdout, <ip>:<port> or :<port> to listen to all local networks")
@@ -113,6 +107,9 @@ There is NO WARRANTY, to the extent permitted by law.`, version, commit, buildDa
 	addFlag(rootCmd, flagEmptyInput)
 	addFlag(rootCmd, flagMaskOneLiner)
 	addFlag(rootCmd, flagProfiling)
+	addFlag(rootCmd, flagRepeat)
+	addFlag(rootCmd, flagRepeatUntil)
+	addFlag(rootCmd, flagRepeatWhile)
 
 	rootCmd.AddCommand(&cobra.Command{
 		Use: "jsonschema",

--- a/cmd/pimo/main.go
+++ b/cmd/pimo/main.go
@@ -55,13 +55,11 @@ var (
 	colormode             string
 	iteration             int
 	emptyInput            bool
-	maskingFile           string
 	cachesToDump          map[string]string
 	cachesToLoad          map[string]string
 	skipLineOnError       bool
 	skipFieldOnError      bool
 	skipLogFile           string
-	catchErrors           string
 	seedValue             int64
 	maskingOneLiner       []string
 	repeatUntil           string
@@ -103,13 +101,11 @@ There is NO WARRANTY, to the extent permitted by law.`, version, commit, buildDa
 	rootCmd.PersistentFlags().StringVar(&colormode, "color", "auto", "use colors in log outputs : yes, no or auto")
 	rootCmd.PersistentFlags().IntVarP(&iteration, "repeat", "r", 1, "number of iteration to mask each input")
 	rootCmd.PersistentFlags().BoolVar(&emptyInput, "empty-input", false, "generate data without any input, to use with repeat flag")
-	rootCmd.PersistentFlags().StringVarP(&maskingFile, "config", "c", "masking.yml", "name and location of the masking-config file")
 	rootCmd.PersistentFlags().StringToStringVar(&cachesToDump, "dump-cache", map[string]string{}, "path for dumping cache into file")
 	rootCmd.PersistentFlags().StringToStringVar(&cachesToLoad, "load-cache", map[string]string{}, "path for loading cache from file")
 	rootCmd.PersistentFlags().BoolVar(&skipLineOnError, "skip-line-on-error", false, "skip a line if an error occurs while masking a field")
 	rootCmd.PersistentFlags().BoolVar(&skipFieldOnError, "skip-field-on-error", false, "remove a field if an error occurs while masking this field")
 	rootCmd.PersistentFlags().StringVar(&skipLogFile, "skip-log-file", "", "skipped lines will be written to this log file")
-	rootCmd.PersistentFlags().StringVarP(&catchErrors, "catch-errors", "e", "", "catch errors and write line in file, same as using skip-field-on-error + skip-log-file")
 	rootCmd.Flags().Int64VarP(&seedValue, "seed", "s", 0, "set seed")
 	rootCmd.PersistentFlags().StringArrayVarP(&maskingOneLiner, "mask", "m", []string{}, "one liner masking")
 	rootCmd.PersistentFlags().StringVar(&repeatUntil, "repeat-until", "", "mask each input repeatedly until the given condition is met")
@@ -120,6 +116,8 @@ There is NO WARRANTY, to the extent permitted by law.`, version, commit, buildDa
 	rootCmd.Flags().StringVar(&profiling, "pprof", "", "create a pprof file - use 'cpu' to create a CPU pprof file or 'mem' to create an memory pprof file")
 
 	addFlag(rootCmd, flagBufferSize)
+	addFlag(rootCmd, flagCatchErrors)
+	addFlag(rootCmd, flagConfigMasking)
 
 	rootCmd.AddCommand(&cobra.Command{
 		Use: "jsonschema",
@@ -192,6 +190,7 @@ There is NO WARRANTY, to the extent permitted by law.`, version, commit, buildDa
 	xmlCmd.Flags().StringToStringVar(&xmlSubscriberName, "subscriber", map[string]string{}, "name of element to mask")
 	xmlCmd.Flags().Int64VarP(&seedValue, "seed", "s", 0, "set seed")
 	addFlag(xmlCmd, flagBufferSize)
+	addFlag(xmlCmd, flagCatchErrors)
 	rootCmd.AddCommand(xmlCmd)
 
 	// Add command for parquet transformer
@@ -213,6 +212,8 @@ There is NO WARRANTY, to the extent permitted by law.`, version, commit, buildDa
 	}
 	parquetCmd.Flags().Int64VarP(&seedValue, "seed", "s", 0, "set seed")
 	addFlag(parquetCmd, flagBufferSize)
+	addFlag(parquetCmd, flagCatchErrors)
+	addFlag(parquetCmd, flagConfigMasking)
 	rootCmd.AddCommand(parquetCmd)
 
 	flowCmd := &cobra.Command{

--- a/cmd/pimo/mock.go
+++ b/cmd/pimo/mock.go
@@ -43,7 +43,7 @@ func setupMockCommand(rootCmd *cobra.Command) {
 	addFlag(mockCmd, flagBufferSize)
 	// addFlag(mockCmd, flagCatchErrors) // could use
 	addFlag(mockCmd, flagConfigRoute)
-	addFlag(mockCmd, flagCachesToDump)
+	// addFlag(mockCmd, flagCachesToDump) // could use
 	addFlag(mockCmd, flagCachesToLoad)
 	// addFlag(mockCmd, flagProfiling) // could use
 	addFlag(mockCmd, flagSeed)
@@ -72,7 +72,7 @@ func runMockCommand(backendURL, mockAddr, configFile string, globalSeed *int64) 
 		log.Fatal().Err(err).Msg("Failed to parse backend URL")
 	}
 
-	ctx, err := cfg.Build(backend, globalSeed)
+	ctx, err := cfg.Build(backend, globalSeed, cachesToLoad)
 	if err != nil {
 		log.Fatal().Err(err).Msgf("Failed to build routes from %s", configFile)
 	}

--- a/cmd/pimo/mock.go
+++ b/cmd/pimo/mock.go
@@ -20,7 +20,8 @@ func setupMockCommand(rootCmd *cobra.Command) {
 	mockAddr := ":8080"
 
 	mockCmd := &cobra.Command{
-		Use: "mock",
+		Use:   "mock",
+		Short: "Use masking configurations to proxyfy remote HTTP service",
 		Run: func(cmd *cobra.Command, args []string) {
 			initLog()
 			if maxBufferCapacity > 0 {

--- a/cmd/pimo/mock.go
+++ b/cmd/pimo/mock.go
@@ -49,6 +49,8 @@ func setupMockCommand(rootCmd *cobra.Command) {
 	// addFlag(mockCmd, flagSkipFieldOnError) // could use
 	// addFlag(mockCmd, flagSkipLineOnError)  // could use
 	// addFlag(mockCmd, flagSkipLogFile)      // could use
+	// addFlag(mockCmd, flagStatsDestination) // could use
+	// addFlag(mockCmd, flagStatsTemplate)    // could use
 
 	rootCmd.AddCommand(mockCmd)
 }

--- a/cmd/pimo/mock.go
+++ b/cmd/pimo/mock.go
@@ -18,7 +18,6 @@ import (
 
 func setupMockCommand(rootCmd *cobra.Command) {
 	mockAddr := ":8080"
-	mockConfigFile := "routes.yaml"
 
 	mockCmd := &cobra.Command{
 		Use: "mock",
@@ -43,6 +42,7 @@ func setupMockCommand(rootCmd *cobra.Command) {
 	mockCmd.PersistentFlags().StringVarP(&mockConfigFile, "config", "c", mockConfigFile, "name and location of the routes config file")
 	mockCmd.Flags().Int64VarP(&seedValue, "seed", "s", 0, "set seed")
 	addFlag(mockCmd, flagBufferSize)
+	addFlag(mockCmd, flagConfigRoute)
 
 	rootCmd.AddCommand(mockCmd)
 }

--- a/cmd/pimo/mock.go
+++ b/cmd/pimo/mock.go
@@ -42,7 +42,7 @@ func setupMockCommand(rootCmd *cobra.Command) {
 	mockCmd.PersistentFlags().StringVarP(&mockAddr, "port", "p", mockAddr, "address and port number")
 	mockCmd.PersistentFlags().StringVarP(&mockConfigFile, "config", "c", mockConfigFile, "name and location of the routes config file")
 	mockCmd.Flags().Int64VarP(&seedValue, "seed", "s", 0, "set seed")
-	mockCmd.Flags().IntVar(&maxBufferCapacity, "buffer-size", defaultBufferCapacity, "buffer size in kB to load data from uri for each line")
+	addFlag(mockCmd, flagBufferSize)
 
 	rootCmd.AddCommand(mockCmd)
 }

--- a/cmd/pimo/mock.go
+++ b/cmd/pimo/mock.go
@@ -39,14 +39,13 @@ func setupMockCommand(rootCmd *cobra.Command) {
 	}
 
 	mockCmd.PersistentFlags().StringVarP(&mockAddr, "port", "p", mockAddr, "address and port number")
-	mockCmd.PersistentFlags().StringVarP(&mockConfigFile, "config", "c", mockConfigFile, "name and location of the routes config file")
-	mockCmd.Flags().Int64VarP(&seedValue, "seed", "s", 0, "set seed")
 	addFlag(mockCmd, flagBufferSize)
 	// addFlag(mockCmd, flagCatchErrors) // could use
 	addFlag(mockCmd, flagConfigRoute)
 	addFlag(mockCmd, flagCachesToDump)
 	addFlag(mockCmd, flagCachesToLoad)
 	// addFlag(mockCmd, flagProfiling) // could use
+	addFlag(mockCmd, flagSeed)
 
 	rootCmd.AddCommand(mockCmd)
 }

--- a/cmd/pimo/mock.go
+++ b/cmd/pimo/mock.go
@@ -46,6 +46,9 @@ func setupMockCommand(rootCmd *cobra.Command) {
 	addFlag(mockCmd, flagCachesToLoad)
 	// addFlag(mockCmd, flagProfiling) // could use
 	addFlag(mockCmd, flagSeed)
+	// addFlag(mockCmd, flagSkipFieldOnError) // could use
+	// addFlag(mockCmd, flagSkipLineOnError)  // could use
+	// addFlag(mockCmd, flagSkipLogFile)      // could use
 
 	rootCmd.AddCommand(mockCmd)
 }

--- a/cmd/pimo/mock.go
+++ b/cmd/pimo/mock.go
@@ -25,18 +25,23 @@ func setupMockCommand(rootCmd *cobra.Command) {
 			initLog()
 			over.MDC().Set("config", mockConfigFile)
 			backendURL := args[0]
-			runMockCommand(backendURL, mockAddr, mockConfigFile)
+			var globalSeed *int64
+			if cmd.Flags().Changed("seed") {
+				globalSeed = &seedValue
+			}
+			runMockCommand(backendURL, mockAddr, mockConfigFile, globalSeed)
 		},
 		Args: cobra.ExactArgs(1),
 	}
 
 	mockCmd.PersistentFlags().StringVarP(&mockAddr, "port", "p", mockAddr, "address and port number")
 	mockCmd.PersistentFlags().StringVarP(&mockConfigFile, "config", "c", mockConfigFile, "name and location of the routes config file")
+	mockCmd.Flags().Int64VarP(&seedValue, "seed", "s", 0, "set seed")
 
 	rootCmd.AddCommand(mockCmd)
 }
 
-func runMockCommand(backendURL, mockAddr, configFile string) {
+func runMockCommand(backendURL, mockAddr, configFile string, globalSeed *int64) {
 	pimo.InjectMasks()
 	statistics.Reset()
 
@@ -52,7 +57,7 @@ func runMockCommand(backendURL, mockAddr, configFile string) {
 		log.Fatal().Err(err).Msg("Failed to parse backend URL")
 	}
 
-	ctx, err := cfg.Build(backend)
+	ctx, err := cfg.Build(backend, globalSeed)
 	if err != nil {
 		log.Fatal().Err(err).Msgf("Failed to build routes from %s", configFile)
 	}

--- a/cmd/pimo/mock.go
+++ b/cmd/pimo/mock.go
@@ -42,9 +42,11 @@ func setupMockCommand(rootCmd *cobra.Command) {
 	mockCmd.PersistentFlags().StringVarP(&mockConfigFile, "config", "c", mockConfigFile, "name and location of the routes config file")
 	mockCmd.Flags().Int64VarP(&seedValue, "seed", "s", 0, "set seed")
 	addFlag(mockCmd, flagBufferSize)
+	// addFlag(mockCmd, flagCatchErrors) // could use
 	addFlag(mockCmd, flagConfigRoute)
 	addFlag(mockCmd, flagCachesToDump)
 	addFlag(mockCmd, flagCachesToLoad)
+	// addFlag(mockCmd, flagProfiling) // could use
 
 	rootCmd.AddCommand(mockCmd)
 }

--- a/cmd/pimo/mock.go
+++ b/cmd/pimo/mock.go
@@ -43,6 +43,8 @@ func setupMockCommand(rootCmd *cobra.Command) {
 	mockCmd.Flags().Int64VarP(&seedValue, "seed", "s", 0, "set seed")
 	addFlag(mockCmd, flagBufferSize)
 	addFlag(mockCmd, flagConfigRoute)
+	addFlag(mockCmd, flagCachesToDump)
+	addFlag(mockCmd, flagCachesToLoad)
 
 	rootCmd.AddCommand(mockCmd)
 }

--- a/cmd/pimo/mock.go
+++ b/cmd/pimo/mock.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cgi-fr/pimo/internal/app/pimo"
 	"github.com/cgi-fr/pimo/internal/app/pimo/mock"
 	"github.com/cgi-fr/pimo/pkg/statistics"
+	"github.com/cgi-fr/pimo/pkg/uri"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )
@@ -23,6 +24,10 @@ func setupMockCommand(rootCmd *cobra.Command) {
 		Use: "mock",
 		Run: func(cmd *cobra.Command, args []string) {
 			initLog()
+			if maxBufferCapacity > 0 {
+				uri.MaxCapacityForEachLine = maxBufferCapacity * 1024
+			}
+
 			over.MDC().Set("config", mockConfigFile)
 			backendURL := args[0]
 			var globalSeed *int64
@@ -37,6 +42,7 @@ func setupMockCommand(rootCmd *cobra.Command) {
 	mockCmd.PersistentFlags().StringVarP(&mockAddr, "port", "p", mockAddr, "address and port number")
 	mockCmd.PersistentFlags().StringVarP(&mockConfigFile, "config", "c", mockConfigFile, "name and location of the routes config file")
 	mockCmd.Flags().Int64VarP(&seedValue, "seed", "s", 0, "set seed")
+	mockCmd.Flags().IntVar(&maxBufferCapacity, "buffer-size", defaultBufferCapacity, "buffer size in kB to load data from uri for each line")
 
 	rootCmd.AddCommand(mockCmd)
 }

--- a/internal/app/pimo/mock/process.go
+++ b/internal/app/pimo/mock/process.go
@@ -1,9 +1,12 @@
 package mock
 
 import (
+	"fmt"
+	"os"
 	"sync"
 
 	"github.com/adrienaury/zeromdc"
+	"github.com/cgi-fr/pimo/pkg/jsonline"
 	"github.com/cgi-fr/pimo/pkg/model"
 )
 
@@ -23,28 +26,36 @@ type Processor struct {
 	pipeline model.SinkedPipeline
 }
 
-func NewProcessor(maskingFile string, globalSeed *int64) (*Processor, error) {
+func NewProcessor(maskingFile string, globalSeed *int64, caches map[string]model.Cache, cachesToLoad map[string]string) (*Processor, map[string]model.Cache, error) {
 	pdef, err := model.LoadPipelineDefinitionFromFile(maskingFile)
 	if err != nil {
-		return nil, err
+		return nil, caches, err
 	}
 
 	if globalSeed != nil {
 		pdef.SetSeed(*globalSeed)
 	}
 
+	for cacheName, cacheDef := range pdef.Caches {
+		if path, ok := cachesToLoad[cacheName]; ok {
+			if err := loadCache(cacheName, caches, path, cacheDef.Reverse, cacheDef.Unique); err != nil {
+				return nil, caches, err
+			}
+		}
+	}
+
 	source := model.NewCallableMapSource()
 
-	pipeline, _, err := model.BuildPipeline(model.NewPipeline(source), pdef, nil, nil, "", "")
+	pipeline, caches, err := model.BuildPipeline(model.NewPipeline(source), pdef, caches, nil, "", "")
 	if err != nil {
-		return nil, err
+		return nil, caches, err
 	}
 
 	return &Processor{
 		mutex:    &sync.Mutex{},
 		source:   source,
 		pipeline: pipeline.AddSink(BlackHoleSink{}),
-	}, nil
+	}, caches, nil
 }
 
 func (p *Processor) Process(dict model.Dictionary) error {
@@ -58,4 +69,41 @@ func (p *Processor) Process(dict model.Dictionary) error {
 	zeromdc.ClearGlobalFields()
 
 	return err
+}
+
+func loadCache(name string, caches map[string]model.Cache, path string, reverse bool, unique bool) error {
+	cache, exists := caches[name]
+	if !exists {
+		if unique {
+			caches[name] = model.NewUniqueMemCache()
+		} else {
+			caches[name] = model.NewMemCache()
+		}
+		cache = caches[name]
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("Cache %s not loaded : %s", name, err.Error())
+	}
+	defer file.Close()
+
+	pipe := model.NewPipeline(jsonline.NewSource(file))
+
+	if reverse {
+		reverseFunc := func(d model.Dictionary) (model.Dictionary, error) {
+			reverse := model.NewDictionary()
+			reverse.Set("key", d.Get("value"))
+			reverse.Set("value", d.Get("key"))
+			return reverse, nil
+		}
+
+		pipe = pipe.Process(model.NewMapProcess(reverseFunc))
+	}
+
+	err = pipe.AddSink(model.NewSinkToCache(cache)).Run()
+	if err != nil {
+		return fmt.Errorf("Cache %s not loaded : %s", name, err.Error())
+	}
+	return nil
 }

--- a/internal/app/pimo/mock/process.go
+++ b/internal/app/pimo/mock/process.go
@@ -23,10 +23,14 @@ type Processor struct {
 	pipeline model.SinkedPipeline
 }
 
-func NewProcessor(maskingFile string) (*Processor, error) {
+func NewProcessor(maskingFile string, globalSeed *int64) (*Processor, error) {
 	pdef, err := model.LoadPipelineDefinitionFromFile(maskingFile)
 	if err != nil {
 		return nil, err
+	}
+
+	if globalSeed != nil {
+		pdef.SetSeed(*globalSeed)
 	}
 
 	source := model.NewCallableMapSource()

--- a/internal/app/pimo/mock/routes.go
+++ b/internal/app/pimo/mock/routes.go
@@ -39,7 +39,7 @@ func LoadConfigFromFile(filename string) (*Config, error) {
 	return config, nil
 }
 
-func (cfg *Config) Build(backend *url.URL) (Context, error) {
+func (cfg *Config) Build(backend *url.URL, globalSeed *int64) (Context, error) {
 	ctx := Context{
 		client:  http.DefaultClient,
 		backend: backend,
@@ -52,14 +52,14 @@ func (cfg *Config) Build(backend *url.URL) (Context, error) {
 		var err error
 
 		if route.Masking.Request != "" {
-			request, err = NewProcessor(route.Masking.Request)
+			request, err = NewProcessor(route.Masking.Request, globalSeed)
 			if err != nil {
 				return ctx, err
 			}
 		}
 
 		if route.Masking.Response != "" {
-			response, err = NewProcessor(route.Masking.Response)
+			response, err = NewProcessor(route.Masking.Response, globalSeed)
 			if err != nil {
 				return ctx, err
 			}

--- a/internal/app/pimo/mock/routes.go
+++ b/internal/app/pimo/mock/routes.go
@@ -39,7 +39,7 @@ func LoadConfigFromFile(filename string) (*Config, error) {
 	return config, nil
 }
 
-func (cfg *Config) Build(backend *url.URL, globalSeed *int64) (Context, error) {
+func (cfg *Config) Build(backend *url.URL, globalSeed *int64, cachesToLoad map[string]string) (Context, error) {
 	ctx := Context{
 		client:  http.DefaultClient,
 		backend: backend,
@@ -52,14 +52,14 @@ func (cfg *Config) Build(backend *url.URL, globalSeed *int64) (Context, error) {
 		var err error
 
 		if route.Masking.Request != "" {
-			request, err = NewProcessor(route.Masking.Request, globalSeed)
+			request, ctx.caches, err = NewProcessor(route.Masking.Request, globalSeed, ctx.caches, cachesToLoad)
 			if err != nil {
 				return ctx, err
 			}
 		}
 
 		if route.Masking.Response != "" {
-			response, err = NewProcessor(route.Masking.Response, globalSeed)
+			response, ctx.caches, err = NewProcessor(route.Masking.Response, globalSeed, ctx.caches, cachesToLoad)
 			if err != nil {
 				return ctx, err
 			}

--- a/pkg/apply/apply.go
+++ b/pkg/apply/apply.go
@@ -64,6 +64,10 @@ func (me MaskEngine) Mask(e model.Entry, context ...model.Dictionary) (model.Ent
 		return nil, err
 	}
 
+	if len(result) == 0 {
+		return nil, nil
+	}
+
 	return result[0], nil
 }
 

--- a/pkg/model/model.go
+++ b/pkg/model/model.go
@@ -279,7 +279,7 @@ type MaskType struct {
 	TimeLine          TimeLineType         `yaml:"timeline,omitempty" json:"timeline,omitempty" jsonschema:"oneof_required=TimeLine,title=TimeLine Mask" jsonschema_description:"Generate a timeline under constraints and rules"`
 	Sequence          SequenceType         `yaml:"sequence,omitempty" json:"sequence,omitempty" jsonschema:"oneof_required=Sequence,title=Sequence Mask" jsonschema_description:"Generate a sequenced ID that follows specified format"`
 	Sha3              Sha3Type             `yaml:"sha3,omitempty" json:"sha3,omitempty" jsonschema:"oneof_required=Sha3,title=Sha3 Mask" jsonschema_description:"Generate a variable-length crytographic hash (collision resistant)"`
-	Apply             ApplyType            `yaml:"apply,omitempty" json:"apply,omitempty" jsonschema:""`
+	Apply             ApplyType            `yaml:"apply,omitempty" json:"apply,omitempty" jsonschema:"oneof_required=Apply,title=Apply Mask" jsonschema_description:"Call external masking file"`
 }
 
 type Masking struct {

--- a/schema/v1/pimo.schema.json
+++ b/schema/v1/pimo.schema.json
@@ -578,6 +578,12 @@
             "sha3"
           ],
           "title": "Sha3"
+        },
+        {
+          "required": [
+            "apply"
+          ],
+          "title": "Apply"
         }
       ],
       "properties": {
@@ -769,7 +775,9 @@
           "description": "Generate a variable-length crytographic hash (collision resistant)"
         },
         "apply": {
-          "$ref": "#/$defs/ApplyType"
+          "$ref": "#/$defs/ApplyType",
+          "title": "Apply Mask",
+          "description": "Call external masking file"
         }
       },
       "additionalProperties": false,

--- a/test/suites/mock.yml
+++ b/test/suites/mock.yml
@@ -72,3 +72,42 @@ testcases:
           - result.code ShouldEqual 0
           - result.systemerr ShouldContainSubstring Origin request={"body":"","captures":{"name":"hello"},"headers":{"Accept":["*/*"],"User-Agent":["curl/8.9.1"]},"method":"GET","protocol":"HTTP/1.1","url":{"path":"/hello"}}
           - result.systemerr ShouldContainSubstring Masked request={"body":"","captures":{"name":"intercepted"},"headers":{"Accept":["*/*"],"User-Agent":["curl/8.9.1"]},"method":"GET","protocol":"HTTP/1.1","url":{"path":"/intercepted"}}
+
+  - name: set global seed
+    steps:
+      - script: |-
+          cat > routes.yaml <<EOF
+          routes:
+          - method: "GET"
+            path: "/{name}"
+            masking:
+              response: "response.yaml"
+          EOF
+      - script: |-
+          cat > response.yaml <<EOF
+          version: "1"
+          masking:
+            - selector:
+                jsonpath: "body.name"
+              mask:
+                randomChoice: ["one", "two", "three"]
+              seed:
+                field: "body.name"
+          EOF
+      - script: |
+          pimo --serve ":8080" --seed 1 --mask 'name=[{add: true}, {randomChoiceInUri: "pimo://nameFR"}]' --mask 'origin=[{add: "{{.name}}"}]' &
+          pimo --seed 2 -v5 mock -p :8081 http://localhost:8080 &
+          sleep 1
+          curl -s http://localhost:8081/
+          curl -s http://localhost:8081/
+          curl -s http://localhost:8081/
+          curl -s http://localhost:8081/
+          curl -s http://localhost:8081/
+          kill %1 %2
+        assertions:
+          - result.code ShouldEqual 0
+          - result.systemerr ShouldContainSubstring Masked response={"body":{"name":"three","origin":"Gwenaëlle"},"headers":{"Content-Length":["44"],"Content-Type":["application/json"]
+          - result.systemerr ShouldContainSubstring Masked response={"body":{"name":"one","origin":"Éléonore"},"headers":{"Content-Length":["44"],"Content-Type":["application/json"]
+          - result.systemerr ShouldContainSubstring Masked response={"body":{"name":"three","origin":"Marie-Noëlle"},"headers":{"Content-Length":["50"],"Content-Type":["application/json"]
+          - result.systemerr ShouldContainSubstring Masked response={"body":{"name":"one","origin":"Hugo"},"headers":{"Content-Length":["32"],"Content-Type":["application/json"]
+          - result.systemerr ShouldContainSubstring Masked response={"body":{"name":"three","origin":"Mathurin"},"headers":{"Content-Length":["40"],"Content-Type":["application/json"]


### PR DESCRIPTION

  |   | mask | mock | xml | parquet | play | jsonschema | flow
-- | -- | -- | -- | -- | -- | -- | -- | --
  | --buffer-size | used | should | should | used | should | not used | not used
-e | --catch-errors | used | could | used | used | not used | not used | not used
  | --color | used | used | used | used | used | could | could
-c | --config | used | used | not used | used | not used | not used | used
  | --debug | used | used | used | used | used | could | could
  | --dump-cache | used | should | used | used | could | not used | not used
  | --empty-input | used | not used | used | used | not used | not used | not used
-h | --help | used | used | used | used | used | used | used
  | --load-cache | used | should | used | used | could | not used | not used
  | --log-json | used | used | used | used | used | could | could
-m | --mask | used | not used | not used | used | not used | not used | not used
  | --pprof | used | could | could | used | not used | not used | not used
-r | --repeat | used | not used | used | used | not used | not used | not used
  | --repeat-until | used | not used | used | used | not used | not used | not used
  | --repeat-while | used | not used | used | used | not used | not used | not used
-s | --seed | used | used | used | used | not used | not used | not used
  | --serve | used | not used | not used | used | not used | not used | not used
  | --skip-field-on-error | used | could | used | used | not used | not used | not used
  | --skip-line-on-error | used | could | used | used | not used | not used | not used
  | --skip-log-file | used | could | used | used | not used | not used | not used
  | --stats | used | could | could | used | not used | not used | not used
  | --statsTemplate | used | could | could | used | not used | not used | not used
-v | --verbosity | used | used | used | used | used | could | could
  | --version | used | not used | not used | not used | not used | not used | not used


